### PR TITLE
Show how to pass -Target argument

### DIFF
--- a/src/Cake.Web/App_Data/docs/fundamentals/running-targets.md
+++ b/src/Cake.Web/App_Data/docs/fundamentals/running-targets.md
@@ -34,3 +34,9 @@ Task("Publish")
 
 RunTarget(target);
 ```
+
+With this Cake script, you can run a specific target by passing the `-Target` argument to `Cake.exe`. Thus, we can run the `"Publish"` target by calling: 
+
+```powershell
+./build.ps1 -Target Publish
+```


### PR DESCRIPTION
This PR makes it more clear that the default build script allows you to specify the target through a command-line argument. It resolves cake-build/cake#618