### PR TITLE
Update and rename criterias.md to criteria.md

### DIFF
--- a/src/Cake.Web/App_Data/docs/fundamentals/criteria.md
+++ b/src/Cake.Web/App_Data/docs/fundamentals/criteria.md
@@ -2,7 +2,7 @@
 content-type: markdown
 ---
 
-You can control and influence the flow of the build script execution by providing criterias. A criteria is a predicate that has to be fulfilled for the task to execute. The criteria does not affect however succeeding task will be executed.
+You can control and influence the flow of the build script execution by providing criteria. This is a predicate that has to be fulfilled for the task to execute. The criteria does not affect however succeeding task will be executed.
 
 ```csharp
 Task("A")
@@ -23,4 +23,4 @@ RunTarget("B");
 
 Task `A`'s criteria will be set when the task is created while Task `B`'s criteria will be evaluated when the task is being executed.
 
-For criterias with states that might change during the execution of the build script, consider using the lambda alternative.
+For criteria with states that might change during the execution of the build script, consider using the lambda alternative.


### PR DESCRIPTION
"Criteria" is the plural form of "criterion". "Criterion" is an ugly word, but not as ugly as "criterias". Technically, a single predicate could involve multiple criteria, so I've just removed the "s".