### PR TITLE
Add Cake.DocFx addin

### DIFF
--- a/src/Cake.Web/App_Data/addins.xml
+++ b/src/Cake.Web/App_Data/addins.xml
@@ -265,4 +265,15 @@
     <Description>Cake AddIn that extends Cake with Git aliases using LibGit2 and LibGit2Sharp.</Description>
     <Categories>Git</Categories>
   </Addin>
+  <Addin>
+    <Name>Cake.DocFx</Name>
+    <NuGet Id="Cake.DocFx">
+      <Filter>/**/Cake.DocFx.dll</Filter>
+      <Filter>/**/Cake.DocFx.xml</Filter>
+    </NuGet>
+    <Repository>https://github.com/reicheltp/Cake.DocFx</Repository>
+    <Author>Paul Reichelt</Author>
+    <Description>Cake AddIn that generates documentation for .Net API reference and markdown files using DocFx.</Description>
+    <Categories>Documentation</Categories>
+  </Addin>
 </Addins>


### PR DESCRIPTION
Adds the Cake.DocFx addin which generates a documentation static site using .Net API reference and markdown.

See: https://github.com/dotnet/docfx