### PR TITLE
Added download of config. Also changed routes for bootstrappers.

### DIFF
--- a/src/Cake.Web/App_Data/docs/tutorials/setting-up-a-new-project.md
+++ b/src/Cake.Web/App_Data/docs/tutorials/setting-up-a-new-project.md
@@ -18,7 +18,7 @@ repository.
 Open a new PowerShell window and run the following command.
 
 ```powershell
-Invoke-WebRequest http://cakebuild.net/bootstrapper/windows -OutFile build.ps1
+Invoke-WebRequest http://cakebuild.net/download/bootstrapper/windows -OutFile build.ps1
 ```
 
 #### Linux
@@ -26,7 +26,7 @@ Invoke-WebRequest http://cakebuild.net/bootstrapper/windows -OutFile build.ps1
 Open a new shell and run the following command.
 
 ```bash
-curl -Lsfo build.sh http://cakebuild.net/bootstrapper/linux
+curl -Lsfo build.sh http://cakebuild.net/download/bootstrapper/linux
 ```
 
 #### OS X
@@ -34,16 +34,13 @@ curl -Lsfo build.sh http://cakebuild.net/bootstrapper/linux
 Open a new shell and run the following command.
 
 ```bash
-curl -Lsfo build.sh http://cakebuild.net/bootstrapper/osx
+curl -Lsfo build.sh http://cakebuild.net/download/bootstrapper/osx
 ```
 
 ### 2. Create a Cake script
 
 Add a cake script called `build.cake` to the same location as the
-bootstrapper script that you downloaded. If you want a script that
-actually do something, check out the
-[minimal, convention based cake script](https://github.com/cake-build/bootstrapper/blob/master/res/scripts/build.cake)
-available in the bootstrapper repository.
+bootstrapper script that you downloaded.
 
 ```csharp
 var target = Argument("target", "Default");

--- a/src/Cake.Web/App_Start/LegacyRouteConfig.cs
+++ b/src/Cake.Web/App_Start/LegacyRouteConfig.cs
@@ -25,7 +25,7 @@ namespace Cake.Web
                 {"documentation/running-targets", "/docs/fundamentals/running-targets"},
                 {"documentation/script-aliases", "/docs/fundamentals/aliases"},
                 {"contribute", "/docs/contributing/guidelines"},
-                {"contribute/contribution-guidelines", "/docs/contributing/guidelines"},
+                {"contribute/contribution-guidelines", "/docs/contributing/guidelines"}
             };
 
             var index = 1;

--- a/src/Cake.Web/App_Start/RouteConfig.cs
+++ b/src/Cake.Web/App_Start/RouteConfig.cs
@@ -96,12 +96,47 @@ namespace Cake.Web
                 new { controller = "Addin", action = "index" }
             );
 
+            RegisterDownloads(routes);
+
             // Default
             routes.MapRoute(
                 name: "Default",
                 url: "{controller}/{action}/{id}",
                 defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
             );
+        }
+
+        private static void RegisterDownloads(RouteCollection routes)
+        {
+            // Downloads: Windows bootstrapper
+            routes.MapRoute(
+                "DownloadBootstrapperWindows", "download/bootstrapper/windows",
+                new { controller = "Download", action = "Windows" }
+                );
+
+            // Downloads: OSX bootstrapper
+            routes.MapRoute(
+                "DownloadBootstrapperOSX", "download/bootstrapper/osx",
+                new { controller = "Download", action = "OSX" }
+                );
+
+            // Downloads: Linux bootstrapper
+            routes.MapRoute(
+                "DownloadBootstrapperLinux", "download/bootstrapper/linux",
+                new { controller = "Download", action = "Linux" }
+                );
+
+            // Downloads: Bootstrapper packages
+            routes.MapRoute(
+                "DownloadBootstrapperPackages", "download/bootstrapper/packages",
+                new { controller = "Download", action = "Packages" }
+                );
+
+            // Downloads: Configuration
+            routes.MapRoute(
+                "DownloadConfiguration", "download/configuration",
+                new { controller = "Download", action = "Configuration" }
+                );
         }
     }
 }

--- a/src/Cake.Web/Cake.Web.csproj
+++ b/src/Cake.Web/Cake.Web.csproj
@@ -149,7 +149,7 @@
     <Compile Include="Controllers\AddinController.cs" />
     <Compile Include="Controllers\ApiController.cs" />
     <Compile Include="Controllers\BlogController.cs" />
-    <Compile Include="Controllers\BootstrapperController.cs" />
+    <Compile Include="Controllers\DownloadController.cs" />
     <Compile Include="Controllers\DocsController.cs" />
     <Compile Include="Controllers\DslController.cs" />
     <Compile Include="Controllers\ErrorController.cs" />
@@ -295,7 +295,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>False</UseIIS>
+          <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>49871</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>

--- a/src/Cake.Web/Controllers/DownloadController.cs
+++ b/src/Cake.Web/Controllers/DownloadController.cs
@@ -3,29 +3,34 @@ using Cake.Web.Core.Content;
 
 namespace Cake.Web.Controllers
 {
-    public class BootstrapperController : Controller
+    public class DownloadController : Controller
     {
         private readonly PackagesConfigContent _content;
 
-        public BootstrapperController(PackagesConfigContent content)
+        public DownloadController(PackagesConfigContent content)
         {
             _content = content;
         }
 
         public ActionResult Windows()
         {
-            return Redirect("https://raw.githubusercontent.com/cake-build/bootstrapper/master/res/scripts/build.ps1");
+            return Redirect("https://raw.githubusercontent.com/cake-build/resources/master/build.ps1");
         }
 
         public ActionResult Linux()
         {
-            return Redirect("https://raw.githubusercontent.com/cake-build/bootstrapper/master/res/scripts/build.sh");
+            return Redirect("https://raw.githubusercontent.com/cake-build/resources/master/build.sh");
         }
 
         // ReSharper disable once InconsistentNaming
         public ActionResult OSX()
         {
-            return Redirect("https://raw.githubusercontent.com/cake-build/bootstrapper/master/res/scripts/build.sh");
+            return Redirect("https://raw.githubusercontent.com/cake-build/resources/master/build.sh");
+        }
+
+        public ActionResult Configuration()
+        {
+            return Redirect("https://raw.githubusercontent.com/cake-build/resources/master/cake.config");
         }
 
         public ActionResult Packages()


### PR DESCRIPTION
New bootstrapper URI's are:

* http://cakebuild.net/download/bootstrapper/windows
* http://cakebuild.net/download/bootstrapper/osx
* http://cakebuild.net/download/bootstrapper/linux
* http://cakebuild.net/download/bootstrapper/packages

Added new route:

* http://cakebuild.net/download/configuration