### PR TITLE
Reworded error-handling.md

### DIFF
--- a/src/Cake.Web/App_Data/docs/fundamentals/error-handling.md
+++ b/src/Cake.Web/App_Data/docs/fundamentals/error-handling.md
@@ -30,7 +30,7 @@ Task("A")
 
 ### Reporting errors
 
-If you want to report an error without affecting it's propagation or resulting stack trace, you can use the `ReportError` task extension. Any exceptions thrown in the scope of `ReportError` will be swallowed.
+If you want to report an error without affecting its propagation or resulting stack trace, you can use the `ReportError` task extension. Any exceptions thrown in the scope of `ReportError` will be swallowed.
 
 ```csharp
 Task("A")


### PR DESCRIPTION
The phrase "without affecting it's propagation or resulting stack trace" is incorrect ("its" is short for "it is" and "its" is the possessive of the pronoun "it".

I have reworded the phrase to use the possessive pronoun.