### PR TITLE
Add AutoRest addin to documentation file

### DIFF
--- a/src/Cake.Web/App_Data/addins.xml
+++ b/src/Cake.Web/App_Data/addins.xml
@@ -287,4 +287,15 @@
     <Description>An alias that generates static sites and other content using Wyam.</Description>
     <Categories>Documentation;Static Site Generation</Categories>
   </Addin>
+  <Addin>
+    <Name>Cake.AutoRest</Name>
+    <NuGet Id="Cake.AutoRest">
+      <Filter>/**/Cake.AutoRest.dll</Filter>
+      <Filter>/**/Cake.AutoRest.xml</Filter>
+    </NuGet>
+    <Repository>https://github.com/agc93/Cake.AutoRest</Repository>
+    <Author>Alistair Chapman</Author>
+    <Description>Cake addin for generating client code from compatible API definitions (including Swagger).</Description>
+    <Categories>Azure</Categories>
+  </Addin>
 </Addins>


### PR DESCRIPTION
Adds the Cake.AutoRest addin which generates client libraries for RESTful API services using the Azure AutoRest tool

See: https://github.com/agc93/Cake.AutoRest