### PR TITLE
Update getting-started.md to reference xUnit instead of NUnit a second time.

### DIFF
--- a/src/Cake.Web/App_Data/docs/tutorials/getting-started.md
+++ b/src/Cake.Web/App_Data/docs/tutorials/getting-started.md
@@ -103,7 +103,7 @@ Task("Run-Unit-Tests")
 });
 ```
 
-This is using NUnit out of the box but you have MSTest and NUnit 
+This is using NUnit out of the box but you have MSTest and xUnit 
 test helpers as well. 
 
 Adding the target doesn't necessarily run it unless another target is 


### PR DESCRIPTION
I'm not sure if it was intended but NUnit is referenced twice and xUnit not at all.