### PR TITLE
Change VSO to VSTS

### DIFF
--- a/src/Cake.Web/Views/Home/Index.cshtml
+++ b/src/Cake.Web/Views/Home/Index.cshtml
@@ -32,7 +32,7 @@
             <h3>Reliable</h3>
             <p>
                 Regardless if you're building on your own machine, or building on a CI system such as AppVeyor,
-                TeamCity, TFS, VSO or Jenkins, Cake is built to behave in the same way.
+                TeamCity, TFS, VSTS or Jenkins, Cake is built to behave in the same way.
             </p>
 
             <h3>Batteries included</h3>


### PR DESCRIPTION
VSO (Visual Studio Online) is now called VSTS (Visual Studio Team Services).