### PR TITLE
Added Cake Kudu deploy script

### DIFF
--- a/.deployment
+++ b/.deployment
@@ -1,0 +1,2 @@
+[config]
+command = deploy.cmd

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ tools/xunit.runners/
 tools/xunit.runner.console/
 tools/nuget.exe
 tools/packages.config.md5sum
+tools/Addins/
+tools/KuduSync.NET/
+LocalDeploy/
+
 
 # mstest test results
 TestResults

--- a/deploy.cake
+++ b/deploy.cake
@@ -1,0 +1,143 @@
+#tool "nuget:https://www.nuget.org/api/v2/?package=KuduSync.NET"
+#addin "nuget:https://www.nuget.org/api/v2/?package=Cake.Kudu"
+///////////////////////////////////////////////////////////////////////////////
+// ARGUMENTS
+///////////////////////////////////////////////////////////////////////////////
+var target          = Argument<string>("target", "Default");
+var configuration   = Argument<string>("configuration", "Release");
+
+///////////////////////////////////////////////////////////////////////////////
+// GLOBAL VARIABLES
+///////////////////////////////////////////////////////////////////////////////
+FilePath        solutionPath        = MakeAbsolute(File("./src/Cake.Web.sln"));
+FilePath        addinsXmlPath       = MakeAbsolute(File("./src/Cake.Web/App_Data/addins.xml"));
+DirectoryPath   websitePublishPath  = MakeAbsolute(Directory("./src/Cake.Web"));
+DirectoryPath   addinPath           = MakeAbsolute(Directory("./src/Cake.Web/App_Data/libs"));
+DirectoryPath   deploymentPath;
+
+
+///////////////////////////////////////////////////////////////////////////////
+// SETUP / TEARDOWN
+///////////////////////////////////////////////////////////////////////////////
+
+Setup(ctx =>
+{
+    if (!Kudu.IsRunningOnKudu)
+    {
+        throw new Exception("Not running on Kudu");
+    }
+
+    deploymentPath = Kudu.Deployment.Target;
+
+    if (!DirectoryExists(deploymentPath))
+    {
+        throw new DirectoryNotFoundException(
+            string.Format(
+                "Deployment target directory not found {0}.",
+                deploymentPath
+                )
+            );
+    }
+
+    // Executed BEFORE the first task.
+    Information("Running tasks...");
+});
+
+Teardown(ctx =>
+{
+    // Executed AFTER the last task.
+    Information("Finished running tasks.");
+});
+
+///////////////////////////////////////////////////////////////////////////////
+// TASK DEFINITIONS
+///////////////////////////////////////////////////////////////////////////////
+
+Task("Clean")
+    .Does(() =>
+{
+    //Clean up any artifacts from previous builds
+    CleanDirectories("./src/**/" + configuration + "/bin");
+    CleanDirectories("./src/**/" + configuration + "/obj");
+    CleanDirectories(new [] {
+        addinPath,
+        "./src/Cake.Web/bin",
+        "./src/Cake.Web/obj"
+        });
+});
+
+Task("Restore")
+    .Does(() =>
+{
+    // Restore all NuGet packages.
+    Information("Restoring {0}...", solutionPath);
+    NuGetRestore(solutionPath);
+});
+
+Task("Build")
+    .IsDependentOn("Clean")
+    .IsDependentOn("Restore")
+    .Does(() =>
+{
+    // Build target web & tests.
+    Information("Building web {0}...", solutionPath);
+    MSBuild(solutionPath, settings =>
+        settings.SetPlatformTarget(PlatformTarget.MSIL)
+            .WithProperty("TreatWarningsAsErrors","true")
+            .WithTarget("Build")
+            .SetConfiguration(configuration));
+});
+
+Task("Prefetch-Addins")
+    .IsDependentOn("Build")
+    .Does(() =>
+{
+    Information("Parsing {0}...", addinsXmlPath);
+    var addinIds = (
+                    from addins in System.Xml.Linq.XDocument.Load(addinsXmlPath.FullPath).Elements("Addins")
+                    from addin in addins.Elements("Addin")
+                    from nuget in addin.Elements("NuGet")
+                    from id in nuget.Attributes("Id")
+                    select id.Value
+                ).ToArray();
+    Information("Found {0} addins.", addinIds.Length);
+
+    foreach(var addinId in addinIds)
+    {
+        try
+        {
+            Information("Installing addin {0}...", addinId);
+            NuGetInstall(addinId, new NuGetInstallSettings {
+                ExcludeVersion  = true,
+                OutputDirectory = addinPath,
+                Source          = new [] { "https://api.nuget.org/v3/index.json" },
+                Verbosity       = NuGetVerbosity.Quiet
+            });
+        }
+        catch
+        {
+            Information("Failed to install addin {0}.", addinId);
+        }
+     }
+});
+
+Task("Publish")
+    .IsDependentOn("Prefetch-Addins")
+    .Does(() =>
+{
+    DeleteDirectory("./src/Cake.Web/obj", recursive:true);
+
+    Information("Deploying web from {0} to {1}...", websitePublishPath, deploymentPath);
+    Kudu.Sync(websitePublishPath);
+});
+
+
+Task("Default")
+    .IsDependentOn("Publish");
+
+
+///////////////////////////////////////////////////////////////////////////////
+// EXECUTION
+///////////////////////////////////////////////////////////////////////////////
+
+RunTarget(target);

--- a/deploy.cmd
+++ b/deploy.cmd
@@ -1,0 +1,6 @@
+@echo off
+IF NOT EXIST "Tools" (md "Tools")
+IF NOT EXIST "Tools\Addins" (md "Tools\Addins")
+nuget install Cake -ExcludeVersion -OutputDirectory "Tools" -Source https://api.nuget.org/v3/index.json
+Tools\Cake\Cake.exe -version
+Tools\Cake\Cake.exe deploy.cake

--- a/localdeploy.cmd
+++ b/localdeploy.cmd
@@ -1,0 +1,46 @@
+@echo off
+SET APPSETTING_ScmType=GitHub
+SET APPSETTING_WEBSITE_AUTH_ENABLED=False
+SET APPSETTING_WEBSITE_NODE_DEFAULT_VERSION=0.10.32
+SET APPSETTING_WEBSITE_SITE_NAME=cakekudu
+SET branch=master
+SET command=deploy.cmd
+SET deployment_branch=master
+SET DEPLOYMENT_SOURCE=%CD%
+SET DEPLOYMENT_TARGET=%CD%\LocalDeploy\wwwroot
+SET DEPLOYMENT_TEMP=%CD%\LocalDeploy\Temp
+SET KUDU_SYNC_CMD=kudusync
+SET MSBUILD_PATH=D:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe
+SET ___NEXT_MANIFEST_PATH=D:\home\site\deployments\cb184fa03bcde2d39e70ca661f75435dfa8f8311\manifest
+SET NPM_JS_PATH=D:\Program Files (x86)\npm\1.4.28\node_modules\npm\bin\npm-cli.js
+SET NUGET_EXE=C:\Program Files (x86)\SiteExtensions\Kudu\47.40908.1797\bin\scripts\nuget.exe
+SET ___PREVIOUS_MANIFEST_PATH=D:\home\site\deployments\53f52a08d83b0053b7eba4ed241889ca4eda09c2\manifest
+SET REGION_NAME=North Europe
+SET SCM_BUILD_ARGS=
+SET SCM_COMMAND_IDLE_TIMEOUT=60
+SET SCM_COMMIT_ID=cb184fa03bcde2d39e70ca661f75435dfa8f8311
+SET SCM_DNVM_PS_PATH=C:\Program Files (x86)\SiteExtensions\Kudu\47.40908.1797\bin\scripts\dnvm.ps1
+SET SCM_GIT_EMAIL=windowsazure
+SET SCM_GIT_USERNAME=windowsazure
+SET SCM_LOGSTREAM_TIMEOUT=1800
+SET SCM_TRACE_LEVEL=1
+SET ScmType=GitHub
+SET WEBROOT_PATH=%CD%\LocalDeploy\wwwroot
+SET WEBSITE_AUTH_ENABLED=False
+SET WEBSITE_COMPUTE_MODE=Shared
+SET WEBSITE_HOSTNAME=cakekudu.azurewebsites.net
+SET WEBSITE_HTTPLOGGING_ENABLED=0
+SET WEBSITE_IIS_SITE_NAME=~1cakekudu
+SET WEBSITE_INSTANCE_ID=0991c182e75e27ae1ae75c5079fd8847da8f5bb675f505a24abf2ff6b87c8c89
+SET WEBSITE_NODE_DEFAULT_VERSION=0.10.32
+SET WEBSITE_OWNER_NAME=01bf0ebb-8e2f-4759-b298-e27cf768979c+devlead-NorthEuropewebspace
+SET WEBSITE_SCM_ALWAYS_ON_ENABLED=0
+SET WEBSITE_SCM_SEPARATE_STATUS=1
+SET WEBSITE_SITE_MODE=Limited
+SET WEBSITE_SITE_NAME=cakekudu
+SET WEBSITE_SKU=Free
+SET WEBSOCKET_CONCURRENT_REQUEST_LIMIT=5
+IF NOT EXIST "%cd%\LocalDeploy" (md "%cd%\LocalDeploy")
+IF NOT EXIST "%cd%\LocalDeploy\Temp" (md "%cd%\LocalDeploy\Temp")
+IF NOT EXIST "%cd%\LocalDeploy\wwwroot" (md "%cd%\LocalDeploy\wwwroot")
+CALL deploy.cmd


### PR DESCRIPTION
This PR adds Cake web deployment script so site can be build & deployed via Azure Web Sites Kudu and have addins fetched as part of deploy and not AppStart.

cake-build website develop branch is published to
http://cakebuilddevelop.azurewebsites.net/

cake-build-bot website develop branch is published to
http://cakebuildbotdevelop.azurewebsites.net/