### PR TITLE
Update 2016-11-09-cake-v0.17.0-released.md

### DIFF
--- a/src/Cake.Web/App_Data/blog/2016-11-09-cake-v0.17.0-released.md
+++ b/src/Cake.Web/App_Data/blog/2016-11-09-cake-v0.17.0-released.md
@@ -8,7 +8,7 @@ Version 0.17.0 of Cake has been released.
 
 This release of Cake sees a number of new features added, as well as some bug fixes, however, most importantly, there was a breaking change.
 
-This breaking change centred around the `VSTestSettings` class, where the decision was wait to allow custom loggers to be passed into the `VSTestRunner`.  As a result, the previous enumeration named `VSTestLogger` has been removed, and replaced with a fully customizable string.  If you are using this enumeration in your scripts then you will see errors being generated if you update to the latest version of Cake.  You should be able to make use of the new extension methods called `WithVisualStudioLogger` and `WithApVeyorLogger` on the `VSTestSettings` to replace the enumeration values.
+This breaking change centred around the `VSTestSettings` class, where the decision was wait to allow custom loggers to be passed into the `VSTestRunner`.  As a result, the previous enumeration named `VSTestLogger` has been removed, and replaced with a fully customizable string.  If you are using this enumeration in your scripts then you will see errors being generated if you update to the latest version of Cake.  You should be able to make use of the new extension methods called `WithVisualStudioLogger` and `WithAppVeyorLogger` on the `VSTestSettings` to replace the enumeration values.
 
 Please let us know if you run into any issues with this latest release.
 


### PR DESCRIPTION
Fix typo in the name of the `WithAppVeyorLogger` extension method (one 'p' was missing)