### PR TITLE
GH223: Add documentation for the CakeNamespaceImportAttribute

### DIFF
--- a/input/docs/fundamentals/aliases.md
+++ b/input/docs/fundamentals/aliases.md
@@ -59,7 +59,32 @@ public static class MyCakeExtension
 }
 ```
 
-# Using the alias
+=======
+#### Importing Namespaces
+Your script alias may need to import one or more namespaces into your Cake script.  Cake supports the automatic import of namespaces with attributes.
+
+The [CakeNamespaceImportAttribute](/api/Cake.Core.Annotations/CakeNamespaceImportAttribute) can be applied at the method, class, or assembly level, or any combination thereof.
+
+```csharp
+// Imports the Cake.Common.IO.Paths namespace into the Cake script for this method only
+[CakeNamespaceImport("Cake.Common.IO.Paths")]
+public static ConvertableDirectoryPath Directory(this ICakeContext context, string path)
+{...}
+```
+
+```csharp
+// Imports the Cake.Common.IO.Paths namespace into the Cake script for any alias method used in the class.
+[CakeNamespaceImport("Cake.Common.IO.Paths")]
+public static class DirectoryAliases
+{...}
+```
+
+```csharp
+// Imports the Cake.Common.IO.Paths namespace into the Cake script for any alias method used in the assembly.
+[assembly: CakeNamespaceImport("Cake.Common.IO.Paths")]
+```
+
+### Using the alias
 
 Compile the assembly and add a reference to it in the build script via the `#r` directive.
 


### PR DESCRIPTION
This is a draft of the documentation for GH-223.

In the original thread at https://github.com/cake-build/cake/issues/1352 it was suggested that this documentation be added
>@kcamp @gep13 this would be under
>http://cakebuild.net/docs/contributing/documentation

It seems that this page relates more to documenting the code itself, and isn't as relevant to a user that might be developing Cake add-ins or script aliases.

For this PR, I added documentation to the page at http://cakebuild.net/docs/fundamentals/aliases
This seems more topically relevant and like it fits better, but I can move it anywhere that we feel it would be serve the community.

If there is feedback on the content, of if you'd like it relocated to the page as originally mentioned, let me know what changes are desired and I'll get them made.

Thanks!