### PR TITLE
Fix addin Cake.Kudu assembly path

### DIFF
--- a/addins/Cake.Kudu.yml
+++ b/addins/Cake.Kudu.yml
@@ -1,7 +1,7 @@
 Name: Cake.Kudu
 NuGet: Cake.Kudu
 Assemblies:
-- "Cake.Kudu.dll"
+- "/**/Cake.Kudu.dll"
 Repository: https://github.com/WCOMAB/Cake.Kudu
 Author: WCOMAB
 Description: "Cake addin to help with Kudu deployments."


### PR DESCRIPTION
Path changed since ported to .NET Core