### PR TITLE
Middle ground fix for built-in/addin alias category collisions

### DIFF
--- a/input/_DslLayout.cshtml
+++ b/input/_DslLayout.cshtml
@@ -74,7 +74,19 @@
                                     <text>@Context.GetTypeLink(alias.Doc, alias.Doc.String("Name"))</text>
                                 }
                             </td>
-                            <td>@Html.Raw(alias.Doc.String(CodeAnalysisKeys.Summary))</td>
+                            <td>
+                                @Html.Raw(alias.Doc.String(CodeAnalysisKeys.Summary))
+                                @{
+                                    IDocument assemblyDoc = alias.Doc.Document(CodeAnalysisKeys.ContainingAssembly);
+                                    if(assemblyDoc != null)
+                                    {
+                                        <text>
+                                            <br/>
+                                            <small><i>Addin from @Context.GetTypeLink(assemblyDoc)</i></small>
+                                        </text>
+                                    }
+                                }
+                            </td>
                         </tr>
                     }
                 </table>

--- a/input/_DslSidebar.cshtml
+++ b/input/_DslSidebar.cshtml
@@ -1,21 +1,23 @@
 @{
-    List<Tuple<string, IDocument, bool>> categories = new List<Tuple<string, IDocument, bool>>();        
+    List<Tuple<string, IDocument, bool, bool>> categories = new List<Tuple<string, IDocument, bool, bool>>();        
     foreach(IDocument group in Documents.FromPipeline("DslAliases"))
     {
-        categories.Add(new Tuple<string, IDocument, bool>(group.String(Keys.GroupKey), group,
-            group.DocumentList(Keys.GroupDocuments).All(y => y.Document(CodeAnalysisKeys.ContainingAssembly) == null)));
+        categories.Add(new Tuple<string, IDocument, bool, bool>(group.String(Keys.GroupKey), group,
+            group.DocumentList(Keys.GroupDocuments).Any(y => y.Document(CodeAnalysisKeys.ContainingAssembly) == null),
+            group.DocumentList(Keys.GroupDocuments).Any(y => y.Document(CodeAnalysisKeys.ContainingAssembly) != null)
+        ));
     }
 }
 
 <li class="header">Built-In</li>
-@foreach(Tuple<string, IDocument, bool> category in categories.Where(x => x.Item3))
+@foreach(Tuple<string, IDocument, bool, bool> category in categories.Where(x => x.Item3))
 {
     string selectedClass = category.Item1 == Model.String(Keys.GroupKey) ? "selected" : null;
     <li class="@selectedClass"><a href="@Context.GetLink(category.Item2)">@category.Item1</a></li>        
 }
 
 <li class="header">Addins</li>
-@foreach(Tuple<string, IDocument, bool> category in categories.Where(x => !x.Item3))
+@foreach(Tuple<string, IDocument, bool, bool> category in categories.Where(x => x.Item4))
 {
     string selectedClass = category.Item1 == Model.String(Keys.GroupKey) ? "selected" : null;
     <li class="@selectedClass"><a href="@Context.GetLink(category.Item2)">@category.Item1</a></li>        

--- a/input/dsl/index.cshtml
+++ b/input/dsl/index.cshtml
@@ -19,15 +19,17 @@ NoSidebar: false
 <p>The DSL is made up of <a href="/docs/fundamentals/aliases">script aliases</a>, that offers specific functionality within the context of a Cake build script. A script alias is an extension method for ICakeContext.</p>
 
 @{
-    List<Tuple<string, string, IDocument, bool>> categories = new List<Tuple<string, string, IDocument, bool>>();        
+    List<Tuple<string, string, IDocument, bool, bool>> categories = new List<Tuple<string, string, IDocument, bool, bool>>();        
     foreach(IDocument group in Documents.FromPipeline("DslAliases"))
     {
         string summary = group
             .DocumentList(Keys.GroupDocuments)
             .Select(x => x.String(CodeAnalysisKeys.Summary))
             .FirstOrDefault(x => !string.IsNullOrEmpty(x)); 
-        categories.Add(new Tuple<string, string, IDocument, bool>(group.String(Keys.GroupKey), summary, group,
-            group.DocumentList(Keys.GroupDocuments).All(y => y.Document(CodeAnalysisKeys.ContainingAssembly) == null)));
+        categories.Add(new Tuple<string, string, IDocument, bool, bool>(group.String(Keys.GroupKey), summary, group,
+            group.DocumentList(Keys.GroupDocuments).Any(y => y.Document(CodeAnalysisKeys.ContainingAssembly) == null),            
+            group.DocumentList(Keys.GroupDocuments).Any(y => y.Document(CodeAnalysisKeys.ContainingAssembly) != null)
+        ));
     }
 }
 <h1 id="built-in">Built-In</h1>
@@ -40,7 +42,7 @@ NoSidebar: false
                     <th>Summary</th>
                 </tr>
             </thead>
-            @foreach(Tuple<string, string, IDocument, bool> category in categories.Where(x => x.Item4))
+            @foreach(Tuple<string, string, IDocument, bool, bool> category in categories.Where(x => x.Item4))
             {
                 <tr>
                     <td><a href="@Context.GetLink(category.Item3)">@category.Item1</a></td>
@@ -61,7 +63,7 @@ NoSidebar: false
                     <th>Summary</th>
                 </tr>
             </thead>
-            @foreach(Tuple<string, string, IDocument, bool> category in categories.Where(x => !x.Item4))
+            @foreach(Tuple<string, string, IDocument, bool, bool> category in categories.Where(x => x.Item5))
             {
                 <tr>
                     <td><a href="@Context.GetLink(category.Item3)">@category.Item1</a></td>


### PR DESCRIPTION
Adds alias categories that contain aliases from both built-in libraries and addin assemblies to both sections of the site (cake-build/website#244)