### PR TITLE
Cake.Http Repository Change

### DIFF
--- a/addins/Cake.Http.yml
+++ b/addins/Cake.Http.yml
@@ -2,7 +2,7 @@ Name: Cake.Http
 NuGet: Cake.Http
 Assemblies:
 - "/**/Cake.Http.dll"
-Repository: https://github.com/louisfischer/Cake.Http
+Repository: https://github.com/cake-contrib/Cake.Http
 Author: Louis Fischer
 Description: "Cake.Http is set of aliases that help simplify HTTP calls for GET, POST, PUT, DELETE, PATCH, etc."
 Categories:


### PR DESCRIPTION
This request is to tweak the  documention for the repository location change. The repository is now hosted under the cake-contrib organization