### PR TITLE
GH283: Add docs for new addin Cake.Android.Adb

### DIFF
--- a/addins/Cake.Android.Adb.yml
+++ b/addins/Cake.Android.Adb.yml
@@ -1,0 +1,9 @@
+Name: Cake.Android.Adb
+NuGet: Cake.Android.Adb
+Assemblies:
+- "/**/Cake.Android.Adb.dll"
+Repository: https://github.com/Redth/Cake.Android.Adb
+Author: Jonathan Dick
+Description: "Cake Aliases for Android's adb command line tool"
+Categories:
+- Android


### PR DESCRIPTION
New Addin: http://github.com/redth/Cake.Android.Adb