### PR TITLE
Proposed change: Add Cake.SynVer, remove Cake.SemVer.FromAssembly

### DIFF
--- a/addins/Cake.SemVer.FromAssembly.yml
+++ b/addins/Cake.SemVer.FromAssembly.yml
@@ -1,9 +1,0 @@
-Name: Cake.SemVer.FromAssembly
-NuGet: Cake.SemVer.FromAssembly
-Assemblies:
-- "/**/Cake.SemVer.FromAssembly.dll"
-Repository: https://github.com/wallymathieu/Cake.SemVer.FromAssembly
-Author: Oskar Gewalli
-Description: "Cake Addin to help get version from assembly differences."
-Categories:
-- Versioning

--- a/addins/Cake.SynVer.yml
+++ b/addins/Cake.SynVer.yml
@@ -1,0 +1,9 @@
+Name: Cake.SynVer
+NuGet: Cake.SynVer
+Assemblies:
+- "/**/Cake.SynVer.dll"
+Repository: https://github.com/fsprojects/Cake.SynVer
+Author: Oskar Gewalli, SPISE MISU ApS (Ramón Soto Mathiesen)
+Description: "Cake Addin to help get version from assembly differences."
+Categories:
+- Versioning


### PR DESCRIPTION
Cake.SemVer.FromAssembly is now obsolete. The role has been taken over by Cake.SynVer.