### PR TITLE
Updates repo urls for gulp and npm packages

### DIFF
--- a/addins/Cake.Gulp.yml
+++ b/addins/Cake.Gulp.yml
@@ -2,7 +2,7 @@ Name: Cake.Gulp
 NuGet: Cake.Gulp
 Assemblies:
 - "/**/Cake.Gulp.dll"
-Repository: https://github.com/philo/cake-gulp
+Repository: https://github.com/cake-contrib/cake-gulp
 Author: Phil Oyston
 Description: "A set of aliases for Cake to help with running Gulp scripts as part of a build."
 Categories:

--- a/addins/Cake.Npm.yml
+++ b/addins/Cake.Npm.yml
@@ -2,7 +2,7 @@ Name: Cake.Npm
 NuGet: Cake.Npm
 Assemblies:
 - "/**/Cake.Npm.dll"
-Repository: https://github.com/philo/cake-npm
+Repository: https://github.com/cake-contrib/cake-npm
 Author: Phil Oyston
 Description: "A set of aliases for Cake to help with running Npm (Node Package Manager) commands."
 Categories:


### PR DESCRIPTION
Following the release of Cake.Npm 0.9.0 the documentation will need a refresh so pushing a change to the repo urls at the same time.