### PR TITLE
GH350: Fix Link for the Cake Visual Studio Extension

### DIFF
--- a/input/docs/editors/visualstudio.md
+++ b/input/docs/editors/visualstudio.md
@@ -4,7 +4,7 @@ Title: Visual Studio
 
 # Syntax Highlighting
 
-Syntax highlighting and Code snippets for .cake files are provided by the **Cake for Visual Studio** extension available from the [Visual Studio Gallery](https://visualstudiogallery.msdn.microsoft.com/). 
+Syntax highlighting and Code snippets for .cake files are provided by the **Cake for Visual Studio** extension available from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=vs-publisher-1392591.CakeforVisualStudio).
 
 # Intellisense
 


### PR DESCRIPTION
The current link to the Cake extension on the Visual Studio Gallery is
outdated. Instead the extension can now be found on the Visual Studio
Marketplace.

Fixes #350 