### PR TITLE
Update a presentation link due to Docs.com end of service

### DIFF
--- a/input/docs/resources/presentations.md
+++ b/input/docs/resources/presentations.md
@@ -5,7 +5,7 @@
 
 ## Igor Fesenko
 
-* [Cake (C# Make)](https://doc.co/vJ7Jr4)([Demo Code](https://github.com/Ky7m/DemoCode/tree/master/CakeBuild))
+* [Cake (C# Make)](https://1drv.ms/p/s!AmdJq1kgIxHUjuNogknwMLZZSQmfiA)([Demo Code](https://github.com/Ky7m/DemoCode/tree/master/CakeBuild))
 
 ## Pedro Marques
 

--- a/input/docs/resources/presentations.md
+++ b/input/docs/resources/presentations.md
@@ -5,7 +5,7 @@
 
 ## Igor Fesenko
 
-* [Cake (C# Make)](https://1drv.ms/p/s!AmdJq1kgIxHUjuNogknwMLZZSQmfiA)([Demo Code](https://github.com/Ky7m/DemoCode/tree/master/CakeBuild))
+* [Cake (C# Make)](https://www.slideshare.net/ssuser8ad51a/cake-c-make-77085334)([Demo Code](https://github.com/Ky7m/DemoCode/tree/master/CakeBuild))
 
 ## Pedro Marques
 


### PR DESCRIPTION
Sorry for the inconvenience.
Presentation has been migrated to personal OneDrive. 
More details about Docs.com end of service  - https://support.office.com/en-us/article/Important-information-about-Docs-com-end-of-service-3b0d4877-1643-457c-9756-8caf28b94da4?ui=en-US&rs=en-US&ad=US