### PR TITLE
Mention the include parameter for tool directive

### DIFF
--- a/input/docs/fundamentals/preprocessor-directives.md
+++ b/input/docs/fundamentals/preprocessor-directives.md
@@ -67,12 +67,14 @@ The tool directive installs external command-line tools using NuGet.
 ## Usage
 The directive takes a single package URI parameter
 Right now, only NuGet packages are supported.
+Specify the `include` parameter if the executable does not end with .exe
 
 ```csharp
 #tool nuget:?package=Cake.Foo
 #tool nuget:?package=Cake.Foo&version=1.2.3
 #tool nuget:?package=Cake.Foo&prerelease
 #tool nuget:https://myget.org/f/Cake/?package=Cake.Foo&prerelease
+#tool nuget:?package=Cake.Foo&include=path/to/foo.cmd
 ```
 
 # Shebang directive


### PR DESCRIPTION
Ran into the log message saying to use the include parameter when using a tool that had a cmd instead of exe.

Didn't see an example of it or it mentioned in the docs.