### PR TITLE
Corrected repository url for Cake.Transifex

### DIFF
--- a/addins/Cake.Transifex.yml
+++ b/addins/Cake.Transifex.yml
@@ -2,7 +2,7 @@ Name: Cake.Transifex
 NuGet: Cake.Transifex
 Assemblies:
 - "/**/Cake.Transifex.dll"
-Repository: https://github.com/WormieCorp/Cake.Transifex
+Repository: https://github.com/cake-contrib/Cake.Transifex
 Author: Kim Nordmo
 Description: "Cake Aliases for using the transifex localization service client"
 Categories:


### PR DESCRIPTION
Since the Cake.Transifex addin have been moved to the cake-contrib
organization, the repository url is no longer valid.
This PR fixes that.