### PR TITLE
GH409: Document 0.22.0 Inproc NuGet config values & pre processor

### DIFF
--- a/input/docs/fundamentals/configuration.md
+++ b/input/docs/fundamentals/configuration.md
@@ -11,17 +11,17 @@ Cake supports the concept of external configuration, to allow the internals of h
 
 ## Where can this configuration be applied?
 
-As an example of where this overridable configuration can be applied, let's look at how Cake determines where the required Roslyn assemblies (which Cake requires in order to function) are downloaded from.  By default, it does this by downloading the nuget packages from the following URL `https://packages.nuget.org/api/v2`.  However, it may be necessary (for example, when running in an offline/local environment) to download these nuget packages from an alternative source.  This is where the Cake Configuration comes into play.
+As an example of where this overridable configuration can be applied, let's look at how Cake determines where to download NuGet packages from. By default, it does this by downloading the nuget packages user configured sources.  However, it may be necessary (for example, when running in an offline/local environment) to download these nuget packages from an alternative source.  This is where the Cake Configuration comes into play.
 
-By creating an Environment variable with the name of `CAKE_ROSLYN_NUGETSOURCE` and setting the value to the URL that is required, Cake will use this alternative download source, rather than the default.
+By creating an Environment variable with the name of `CAKE_NUGET_SOURCE` and setting the value to the URL that is required, Cake will use this alternative download source, rather than the defaults.
 
 Alternatively, you can create a `cake.config` file with the following content:
 
 ```sh
 ; The configuration file for Cake.
 
-[Roslyn]
-NuGetSource=https://mycustomurl
+[Nuget]
+Source=https://mycustomurl
 ```
 <br/>
 Specifying a configuration value within a configuration file will override the same configuration value stored within an equivalent Environment variable.
@@ -31,7 +31,7 @@ Specifying a configuration value within a configuration file will override the s
 Finally, you can specify an input parameter directly to the Cake.exe, in the following format:
 
 ```sh
-cake.exe --roslyn_nugetsource=http://mycustomurl
+cake.exe --nuget_source=http://mycustomurl
 ```
 <br/>
 Passing a configuration value directly to the Cake.exe will override the same configuration value stored within an Environment variable and also any stored in a local configuration file.

--- a/input/docs/fundamentals/default-configuration-values.md
+++ b/input/docs/fundamentals/default-configuration-values.md
@@ -34,37 +34,6 @@ cake.exe --nuget_source=http://myfeed/nuget/
 
 <hr/>
 
-# Roslyn NuGet Download Url
-
-This allows the control of where Cake downloads the required Roslyn NuGet packages.  This can be useful when it is necessary to work in an offline mode, where direct access to nuget.org is not available.
-
-## Default Value
-
-```sh
-https://packages.nuget.org/api/v2
-```
-
-## Environment Variable Name
-
-```sh
-CAKE_ROSLYN_NUGETSOURCE
-```
-
-## ini File Contents
-
-```sh
-[Roslyn]
-NuGetSource=https://mycustomurl
-```
-
-## Direct Argument
-
-```sh
-cake.exe --roslyn_nugetsource=http://mycustomurl
-```
-
-<hr/>
-
 # Tools Path
 
 This allows the configuration of the tools folder which is used by Cake when restoring tools.
@@ -198,3 +167,118 @@ SkipVerification=true
 ```sh
 cake.exe --settings_skipverification=true
 ```
+
+<hr/>
+
+# In-Process NuGet installation
+
+From Cake version `0.22.0` you can opt-in to not use `NuGet.exe` but instead let Cake handle the installation of addins, tools and scripts in-process.
+
+## Default Value
+
+```sh
+false
+```
+
+## Valid Values
+
+```sh
+true
+or
+false
+```
+
+## Environment Variable Name
+
+```sh
+CAKE_NUGET_USEINPROCESSCLIENT
+```
+
+## ini File Contents
+
+```sh
+[NuGet]
+UseInProcessClient=true
+```
+
+## Direct Argument
+
+```sh
+cake.exe --nuget_useinprocessclient=true
+```
+
+
+<hr/>
+
+# Addin NuGet dependencies
+
+When using In-Process NuGet installation available since Cake `0.22.0`, you now got the option to opt-in to installing and referencing NuGet package dependencies.
+
+## Default Value
+
+```sh
+false
+```
+
+## Valid Values
+
+```sh
+true
+or
+false
+```
+
+## Environment Variable Name
+
+```sh
+CAKE_NUGET_LOADDEPENDENCIES
+```
+
+## ini File Contents
+
+```sh
+[NuGet]
+LoadDependencies=true
+```
+
+## Direct Argument
+
+```sh
+cake.exe --nuget_loaddependencies=true
+```
+
+
+<hr/>
+
+# Roslyn NuGet Download Url
+
+**_This only applies to Cake version `0.21.1` and older, Roslyn ships with Cake from version `0.22.0`._**
+
+This allows the control of where Cake downloads the required Roslyn NuGet packages.  This can be useful when it is necessary to work in an offline mode, where direct access to nuget.org is not available.
+
+## Default Value
+
+```sh
+https://packages.nuget.org/api/v2
+```
+
+## Environment Variable Name
+
+```sh
+CAKE_ROSLYN_NUGETSOURCE
+```
+
+## ini File Contents
+
+```sh
+[Roslyn]
+NuGetSource=https://mycustomurl
+```
+
+## Direct Argument
+
+```sh
+cake.exe --roslyn_nugetsource=http://mycustomurl
+```
+
+<hr/>

--- a/input/docs/fundamentals/preprocessor-directives.md
+++ b/input/docs/fundamentals/preprocessor-directives.md
@@ -18,12 +18,24 @@ Right now, only NuGet packages are supported.
 #addin nuget:https://myget.org/f/Cake/?package=Cake.Foo&prerelease
 ```
 
+### Dependencies
+
+From Cake version 0.22.0 there's an option to fetch and load NuGet dependencies
+
+```csharp
+#addin nuget:?package=foo&loaddependencies=true
+or
+#addin nuget:?package=foo.bar&loaddependencies=false
+```
+
+This feature requires Cake to be [configured](/fundamentals/configuration.md) to not use `nuget.exe` but instead let Cake handle NuGet installation in-process.
+
 # Load directive
 The load directive is used to reference external Cake scripts. Useful i.e. if you have common utility functions.
 Starting from 0.18.0 you can also load cake scripts from nuget.
 
 ## Usage
-The directive has one parameter which is the location to the script which optionally includes a scheme: `local` or `nuget`. The default is `local`. 
+The directive has one parameter which is the location to the script which optionally includes a scheme: `local` or `nuget`. The default is `local`.
 
 ### Default:
 ```csharp


### PR DESCRIPTION
* fixes #409 
* As Roslyn isn't an good example anymore I changed that to something that's still relevant, also moved it to the end of default config values.