### PR TITLE
[fundamentals] Add macOS example for setting arguments

### DIFF
--- a/input/docs/fundamentals/args-and-environment-vars.md
+++ b/input/docs/fundamentals/args-and-environment-vars.md
@@ -46,6 +46,16 @@ The output is
 My setting is: from a batch file
 ```
 
+Bash (Linux/macOS):
+```
+./build.sh --my_setting="from Bash"
+```
+
+The output is
+```
+My setting is: from Bash
+```
+
 # Environment Variables
 
 


### PR DESCRIPTION
Since I was having trouble figuring out how to pass arguments to a Cake script on a Bash environment, I figured I'd add an example in the first place I looked unsuccessfully.