### PR TITLE
Fixed 'IsDependencyOf' blog typo

### DIFF
--- a/input/blog/2017-10-15-cake-v0.23.0-released.md
+++ b/input/blog/2017-10-15-cake-v0.23.0-released.md
@@ -46,7 +46,7 @@ Since task `A` is configured to be a dependee of `B` the task definition will be
 
 ```csharp
 Task("A");
-Task("B").IsDependencyOf("A");
+Task("B").IsDependentOn("A");
 
 RunTarget("B");
 ```


### PR DESCRIPTION
We never had `IsDependencyOf`, sadly, but if we did, it would by a synonym for `IsDependeeOf`. This example meant to use `IsDependentOn` as the antonym.