### PR TITLE
Adds an addin notice to extension methods that come from an addin (#375)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 nuget.exe
 [Ll]ocal[Dd]eploy/
 packages.xml
+/config.wyam.dll
+/config.wyam.hash

--- a/input/Shared/Section/_ExtensionMethods.cshtml
+++ b/input/Shared/Section/_ExtensionMethods.cshtml
@@ -1,0 +1,60 @@
+@using Microsoft.AspNetCore.Html;
+@using Microsoft.CodeAnalysis;
+@{
+	ITypeSymbol modelSymbol = Model.Get<ITypeSymbol>("Symbol");
+	IList<IDocument> methods = Model.List<IDocument>("ExtensionMethods")
+		?.Where(x => x.Bool("IsResult"))
+		.OrderBy(x => x["DisplayName"])
+		.ToList();
+	if(methods.Count > 0)
+	{
+		<text>
+			<h1 id="ExtensionMethods">Extension Methods</h1>
+			<div class="box">
+				<div class="box-body no-padding table-responsive">
+					<table class="table table-striped table-hover three-cols">
+						<thead>
+							<tr>
+								<th>Name</th>
+								<th>Value</th>
+								<th>Summary</th>
+							</tr>
+						</thead>
+						@foreach(IDocument method in methods)
+						{
+							ISymbol reducedSymbol = method.Get<IMethodSymbol>("Symbol")?.ReduceExtensionMethod(modelSymbol);
+							string reducedName = reducedSymbol?.ToDisplayString(new SymbolDisplayFormat(
+								typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+								genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+								parameterOptions: SymbolDisplayParameterOptions.IncludeType, 
+								memberOptions: SymbolDisplayMemberOptions.IncludeParameters,
+								miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+							IDocument returnType = method.Get<IDocument>("ReturnType");
+							<tr>
+								<td>@Context.GetTypeLink(method, reducedName)</td>
+								<td>@(returnType == null ? new HtmlString(string.Empty) : Context.GetTypeLink(returnType))</td>
+								<td>
+									<div>@Html.Raw(method["Summary"])</div>
+									@{
+										IDocument containingType = method.Document(CodeAnalysisKeys.ContainingType);
+										<div><small><em>From @Context.GetTypeLink(containingType)</em></small></div>
+
+                                        // Display a message if the extension is from an addin
+                                        IDocument containingAssembly = containingType.Get<IDocument>("ContainingAssembly");
+                                        if(containingAssembly != null)
+                                        {
+                                            IDocument addin = Documents["Addins"]
+                                                .FirstOrDefault(x => x.List<string>("Assemblies")
+                                                    ?.Any(y => y.Contains(containingAssembly.String(CodeAnalysisKeys.DisplayName))) == true);
+                                            <div><small><em>Requires the @addin.String("Name") addin</em></small></div>
+                                        }
+									}
+								</td>
+							</tr>
+						}
+					</table>
+				</div>
+			</div>
+		</text>
+	}
+}


### PR DESCRIPTION
The `.gitignore` change is totally separate, but figured I'd get it in this PR. It ignores the cached config file compilation that was introduced with Wyam 1.0 (we probably want it fresh each time for CI).

Resolves #375