### PR TITLE
Limits DSL categories to distinct values (#356)

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -27,7 +27,8 @@ Pipelines.InsertAfter("Addins", "AddinCategories",
 Pipelines.InsertAfter(Docs.Api, "DslAliases",
     GroupByMany(@doc.DocumentList(CodeAnalysisKeys.Attributes)
         .Where(attr => attr.String(CodeAnalysisKeys.Name) == "CakeAliasCategoryAttribute")
-        .Select(attr => attr.Get<Microsoft.CodeAnalysis.AttributeData>(CodeAnalysisKeys.AttributeData).ConstructorArguments.FirstOrDefault().Value),
+        .Select(attr => attr.Get<Microsoft.CodeAnalysis.AttributeData>(CodeAnalysisKeys.AttributeData).ConstructorArguments.FirstOrDefault().Value)
+        .Distinct(),
         Documents(Docs.Api),
         Where(@doc.String(CodeAnalysisKeys.Kind) == "NamedType"
             && @doc.DocumentList(CodeAnalysisKeys.Attributes)


### PR DESCRIPTION
Resolves #356. Even though there's no longer a problem in the Docker alias (that was resolved by removing the redundant `CakeAliasCategoryAttribute` directly), you can still see the problem in action at http://cakebuild.net/dsl/signing/

You don't pay me the big bucks for adding a single line, you pay me the big bucks for knowing which line to add.