### PR TITLE
Path fixes for addin specs

### DIFF
--- a/addins/Cake.MSBuildTask.yml
+++ b/addins/Cake.MSBuildTask.yml
@@ -1,7 +1,7 @@
 Name: Cake.MSBuildTask
 NuGet: Cake.MSBuildTask
 Assemblies:
-- "Cake.MSBuildTask.dll"
+- "/**/Cake.MSBuildTask.dll"
 Repository: https://github.com/marcosnz/Cake.MSBuildTask
 Author: Mark Walker
 Description: "Adds ability to run any MSBuild task from a Cake script."

--- a/addins/Cake.Slack.yml
+++ b/addins/Cake.Slack.yml
@@ -1,7 +1,7 @@
 Name: Cake.Slack
 NuGet: Cake.Slack
 Assemblies:
-- "Cake.Slack.dll"
+- "/**/Cake.Slack.dll"
 Repository: https://github.com/WCOMAB/Cake.Slack
 Author: WCOMAB
 Description: "Cake Addin that extends Cake with Slack messaging features."

--- a/addins/Cake.Svn.yml
+++ b/addins/Cake.Svn.yml
@@ -1,7 +1,7 @@
 Name: Cake.Svn
 NuGet: Cake.Svn
 Assemblies:
-- "Cake.Svn.dll"
+- "/**/Cake.Svn.dll"
 Repository: https://github.com/cake-contrib/Cake.Svn
 Author: Martin Björkström, Pascal Berger and contributors
 Description: "Addin that extends the Cake build automation system with Subversion features using SharpSvn."

--- a/build.cake
+++ b/build.cake
@@ -193,7 +193,19 @@ Task("Debug")
     .Does(() =>
     {
         StartProcess("../Wyam/src/clients/Wyam/bin/Debug/wyam.exe",
-            "-a \"../Wyam/src/**/bin/Debug/*.dll\" -r \"docs -i\" -t \"../Wyam/themes/Docs/Samson\" -p --attach");
+            "-a \"../Wyam/src/**/bin/Debug/**/*.dll\" -r \"docs -i\" -t \"../Wyam/themes/Docs/Samson\" -p");
+    });
+    
+// Does not download artifacts (run Build or GetArtifacts target first)
+Task("Debug-Addins")
+    .IsDependentOn("GetAddinSpecs")
+    .Does(() =>
+    {
+        StartProcess("../Wyam/src/clients/Wyam/bin/Debug/wyam.exe",
+            "-a \"../Wyam/src/**/bin/Debug/**/*.dll\" -r \"docs -i\" -t \"../Wyam/themes/Docs/Samson\" -p --attach"
+            + " --setting \"AssemblyFiles=["
+            + String.Join(",", addinSpecs.Where(x => x.Assemblies != null).SelectMany(x => x.Assemblies).Select(x => "../release/addins" + x))
+            + "]\"");
     });
 
 Task("Copy-Bootstrapper-Download")


### PR DESCRIPTION
Turns out a few of the addin specifications had invalid assembly paths. Also snuck in a small build script enhancement for local debugging of addins docs.

Resolves #427