### PR TITLE
Replace OS X with macOS

### DIFF
--- a/input/docs/tutorials/setting-up-a-new-project.md
+++ b/input/docs/tutorials/setting-up-a-new-project.md
@@ -67,9 +67,9 @@ If script execution fail due to the execution policy, you might have to
 tell PowerShell to allow running scripts. You do this by
 [changing the execution policy](https://technet.microsoft.com/en-us/library/ee176961.aspx).
 
-## Linux/OS X
+## Linux/macOS
 
-To be able to execute the bash script on Linux or OS X you should
+To be able to execute the bash script on Linux or macOS you should
 give the owner of the script permission to execute it.
 
 ```bash

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -24,7 +24,7 @@ NoGutter: true
 
             <h3>Cross platform</h3>
             <p>
-                Cake is available on Windows, Linux and OS X.
+                Cake is available on Windows, Linux and macOS.
             </p>
 
             <h3>Reliable</h3>


### PR DESCRIPTION
'macOS' is more suitable than 'OS X'.