### PR TITLE
Add the Cake.NDepend to the addins

### DIFF
--- a/addins/Cake.NDepend
+++ b/addins/Cake.NDepend
@@ -1,0 +1,12 @@
+Name: Cake.NDepend
+NuGet: Cake.NDepend
+Prerelease: false
+Assemblies:
+- "/**/Cake.NDepend.dll"
+Repository: https://github.com/joaoasrosa/cake-ndepend
+Author: João Rosa
+Description: "An alias wrapping the NDepend.Console command line tool."
+Categories:
+- Code Quality
+- NDepend
+- Reports


### PR DESCRIPTION
This PR adds the `Cake.NDepend` addin to the Cake website.