### PR TITLE
add parallelization example to asynchronous tasks

### DIFF
--- a/input/docs/fundamentals/asynchronous-tasks.md
+++ b/input/docs/fundamentals/asynchronous-tasks.md
@@ -9,17 +9,62 @@ Tasks will still execute single threaded and in order as before, but this really
 
 ```csharp
 Task("Copy-To-Memory-Async")
-    .Does(async () => {
-    IFile file = Context.FileSystem.GetFile("./test.txt");
-    using(Stream
+    .Does(async () => 
+    {
+        IFile file = Context.FileSystem.GetFile("./test.txt");
+        using(Stream
             inputStream = testFile.OpenRead(),
             outputStream = new MemoryStream())
-    {
-        await inputStream.CopyToAsync(outputStream);
-        await outputStream.FlushAsync();
-        Information("Copied {0} bytes into memory.",
-            outputStream.Length
+        {
+            await inputStream.CopyToAsync(outputStream);
+            await outputStream.FlushAsync();
+            Information("Copied {0} bytes into memory.",
+                outputStream.Length
             );
+        }
+    });   
+```
+
+You can also use any parallelization mechanism such as Parallel.ForEach or Parallel.Invoke on your tasks.
+
+```csharp
+var projectPaths = new [] {
+    "./src/First/First.csproj",
+    "./src/Second/Second.csproj",
+};
+
+Task("BuildProjectsInParallel")
+    .Does(() => 
+    {
+        BuildInParallel(projectPaths);
+    });
+
+Task("Default")
+    .IsDependentOn("BuildProjectsInParallel")
+    .Does(() => 
+    {
+    });
+    
+RunTarget(target);
+
+public void BuildInParallel(
+    IEnumerable<string> filePaths,
+    int maxDegreeOfParallelism = -1,
+    CancellationToken cancellationToken = default(CancellationToken)) 
+{
+    var actions = new List<Action>();
+    foreach (var filePath in filePaths) {
+        actions.Add(() =>
+            MSBuild(filePath, configurator =>
+                configurator.SetConfiguration("Release"))
+        );                        
     }
-});
+
+    var options = new ParallelOptions {
+        MaxDegreeOfParallelism = maxDegreeOfParallelism,
+        CancellationToken = cancellationToken
+    };
+
+    Parallel.Invoke(options, actions.ToArray());
+}
 ```


### PR DESCRIPTION
Following a suggestion from @gep13 I add this small example to the asynchronous section on fundamentals. 

Implements #456 