### PR TITLE
 Add Cake.Tfs.AutoMerge configuration.

### DIFF
--- a/addins/Cake.Tfs.AutoMerge.yml
+++ b/addins/Cake.Tfs.AutoMerge.yml
@@ -1,0 +1,9 @@
+Name: Cake.Tfs.AutoMerge
+NuGet: Cake.Tfs.AutoMerge
+Assemblies:
+- "/**/Cake.Tfs.AutoMerge.dll"
+Repository: https://github.com/mabreuortega/Cake.Tfs
+Author: mabreu
+Description: "Cake Aliases for auto merge Git Branches using TFS Pull Requests."
+Categories:
+- TFS

--- a/addins/Cake.Tfs.Build.Variables.yml
+++ b/addins/Cake.Tfs.Build.Variables.yml
@@ -6,4 +6,4 @@ Repository: https://github.com/Kemyke/Cake.Tfs.Build.Variables
 Author: Attila Kemeny
 Description: "Retrieving TFS variable from arguments or environment variables"
 Categories:
-- Tfs
+- TFS


### PR DESCRIPTION
- Fix Camel case "Tfs" category causing TFS to be listed twice on the addins page.
- Add Cake.Tfs.AutoMerge configuration.