### PR TITLE
Update .NET Framework requirement to 4.6.1

### DIFF
--- a/input/docs/overview/requirements.md
+++ b/input/docs/overview/requirements.md
@@ -5,8 +5,8 @@ Order: 20
 
 You can use the [Cake.CoreCLR](https://www.nuget.org/packages/Cake.CoreCLR) NuGet package to run cross-platform on Windows, Mac or Linux using [.NET Core](https://www.microsoft.com/net/core#windows).
 
-# .NET Framework 4.5
+# .NET Framework 4.6.1
 
-The [Cake](https://www.nuget.org/packages/Cake) NuGet package can be used on Windows to run using the full [.NET Framework 4.5](https://www.microsoft.com/en-us/download/details.aspx?id=30653).
+The [Cake](https://www.nuget.org/packages/Cake) NuGet package can be used on Windows to run using the full [.NET Framework 4.6.1](https://www.microsoft.com/en-us/download/details.aspx?id=49981).
 
 Alternatively, you can also use [Mono](http://www.mono-project.com/) to run on Mac or Linux. The official recommended version of Mono is `4.4.2`. Older versions might work but are not supported.


### PR DESCRIPTION
Cake v0.22.0 or later requires .NET Framework 4.6.1 to run.