### PR TITLE
Enabled parallel addin installation

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -133,25 +133,26 @@ Task("GetAddinPackages")
     .Does(() =>
     {
         DirectoryPath   packagesPath        = MakeAbsolute(Directory("./output")).Combine("packages");
-        foreach(var addinSpec in addinSpecs.Where(x => !string.IsNullOrEmpty(x.NuGet)))
-        {
-            Information("Installing addin package " + addinSpec.NuGet);
-            NuGetInstall(addinSpec.NuGet,
-                new NuGetInstallSettings
-                {
-                    OutputDirectory = addinDir,
-                    Prerelease = addinSpec.Prerelease,
-                    Verbosity = NuGetVerbosity.Quiet,
-                    Source = new [] { "https://api.nuget.org/v3/index.json" },
-                    NoCache = true,
-                    EnvironmentVariables    = new Dictionary<string, string>{
-                                                    {"EnableNuGetPackageRestore", "true"},
-                                                    {"NUGET_XMLDOC_MODE", "None"},
-                                                    {"NUGET_PACKAGES", packagesPath.FullPath},
-                                                    {"NUGET_EXE",  Context.Tools.Resolve("nuget.exe").FullPath }
-                                              }
-                });
-        }
+        Parallel.ForEach(
+            addinSpecs.Where(x => !string.IsNullOrEmpty(x.NuGet)),
+            addinSpec => {
+                Information("Installing addin package " + addinSpec.NuGet);
+                NuGetInstall(addinSpec.NuGet,
+                    new NuGetInstallSettings
+                    {
+                        OutputDirectory = addinDir,
+                        Prerelease = addinSpec.Prerelease,
+                        Verbosity = NuGetVerbosity.Quiet,
+                        Source = new [] { "https://api.nuget.org/v3/index.json" },
+                        NoCache = true,
+                        EnvironmentVariables    = new Dictionary<string, string>{
+                                                        {"EnableNuGetPackageRestore", "true"},
+                                                        {"NUGET_XMLDOC_MODE", "None"},
+                                                        {"NUGET_PACKAGES", packagesPath.FullPath},
+                                                        {"NUGET_EXE",  Context.Tools.Resolve("nuget.exe").FullPath }
+                                                  }
+                    });
+        });
     });
 
 Task("Build")


### PR DESCRIPTION
Attempt to speed up build process by doing addin installation in parallel, locally it made quite the difference, but might have side effects.

```diff
- GetAddinPackages              00:08:33.5422183
+ GetAddinPackages              00:01:42.6093914
```