### PR TITLE
Polish homepage blurb

### DIFF
--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -6,7 +6,7 @@ NoGutter: true
 <div class="jumbotron">
     <div class="container">
         <h1>What is Cake?</h1>
-        <p>Cake (C# Make) is a cross platform build automation system with a C# DSL to do things like compiling code, copy files/folders, running unit tests, compress files and build NuGet packages.</p>
+        <p>Cake (C# Make) is a cross-platform build automation system with a C# DSL for tasks such as compiling code, copying files and folders, running unit tests, compressing files and building NuGet packages.</p>
         <p>
             <a class="btn btn-primary btn-lg" href="/docs/tutorials/getting-started" role="button">Get Started &raquo;</a>
         </p>


### PR DESCRIPTION
Verbs were alternating between gerunds (-ing) and infinitive (no -ing).
Removed the word 'like' and the slash. Hyphenated 'cross-platform.'