### PR TITLE
Add prerelease flag to Cake.SqlTools

### DIFF
--- a/addins/Cake.SqlTools.yml
+++ b/addins/Cake.SqlTools.yml
@@ -5,6 +5,7 @@ Assemblies:
 Repository: https://github.com/SharpeRAD/Cake.SqlTools
 Author: SharpeRAD
 Description: "Cake Build addin for executing sql scripts against a database"
+Prerelease: true
 Categories:
 - Sql
 - Database


### PR DESCRIPTION
Cake.SqlTools 0.2.0 (latest) depends on MySql.Data >= 8.0.10-rc, which is marked as prerelease