### PR TITLE
Fix typo in Addin category name

### DIFF
--- a/addins/Cake.DependenciesAnalyser.yml
+++ b/addins/Cake.DependenciesAnalyser.yml
@@ -10,5 +10,5 @@ Author: João Rosa
 Description: "An addin to verify if the NuGet dependencies of a C# Project are up-to-date. Produces an inline report."
 Categories:
 - Code Quality
-- Dependencies Analyaser
+- Dependencies Analyser
 - Reports


### PR DESCRIPTION
This PR fixes a typo in the addin category name.