### PR TITLE
Made a small runner for VSTS users wanting coverage

### DIFF
--- a/addins/Cake.OpenCoverToCoberturaConverter.yml
+++ b/addins/Cake.OpenCoverToCoberturaConverter.yml
@@ -1,0 +1,10 @@
+Name: Cake.OpenCoverToCoberturaConverter
+NuGet: Cake.OpenCoverToCoberturaConverter
+Assemblies:
+- "/**/Cake.OpenCoverToCoberturaConverter.dll"
+Repository: https://github.com/volak/Cake.OpenCoverToCoberturaConverter
+Author: Charles Solar
+Description: "Converts OpenCover xml report to Cobertura format - for use with VSTS"
+Categories:
+- Code Coverage
+- VSTS


### PR DESCRIPTION
VSTS's code coverage tracking is not great but it can track Cobertura and JaCoco report formats.  After finding the exe to convert OpenCover reports I wrote up this little runner so cake build can convert opencover reports and VSTS can import those results to each build.