### PR TITLE
Use prerelease tag for Cake.Compression

### DIFF
--- a/addins/Cake.Compression.yml
+++ b/addins/Cake.Compression.yml
@@ -1,5 +1,6 @@
 Name: Cake.Compression
 NuGet: Cake.Compression
+Prerelease: true
 Assemblies:
 - "/**/Cake.Compression.dll"
 Repository: https://github.com/akordowski/Cake.Compression/


### PR DESCRIPTION
Use prerelease tag for Cake.Compression since it has a prerelease dependency with [0.2.1](https://github.com/akordowski/Cake.Compression/releases/tag/0.2.1)