### PR TITLE
Updates Wyam to 1.6.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,8 +1,8 @@
 #tool "nuget:https://api.nuget.org/v3/index.json?package=KuduSync.NET&version=1.3.1"
-#tool "nuget:https://api.nuget.org/v3/index.json?package=Wyam&version=1.5.0"
+#tool "nuget:https://api.nuget.org/v3/index.json?package=Wyam&version=1.6.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Git&version=0.16.1"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Kudu&version=0.5.0"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=1.5.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=1.6.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Yaml&version=2.0.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=YamlDotNet&version=4.2.1"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.26.0"
@@ -205,7 +205,7 @@ Task("Debug")
     .Does(() =>
     {
         StartProcess("../Wyam/src/clients/Wyam/bin/Debug/net462/wyam.exe",
-            "-a \"../Wyam/tests/integration/Wyam.Examples.Tests/bin/Debug/net462/**/*.dll\" -r \"docs -i\" -t \"../Wyam/themes/Docs/Samson\" -p");
+            "-a \"../Wyam/tests/integration/Wyam.Examples.Tests/bin/Debug/net462/**/*.dll\" -r \"docs -i\" -t \"../Wyam/themes/Docs/Samson\" -p --attach");
     });
 
 // Does not download artifacts (run Build or GetArtifacts target first)

--- a/config.wyam
+++ b/config.wyam
@@ -18,7 +18,8 @@ Pipelines.InsertBefore(Docs.Code, "Addins",
 Pipelines.InsertAfter("Addins", "AddinCategories",
     GroupByMany(@doc.List<string>("Categories"),
         Documents("Addins")
-    ),
+    )
+        .WithEmptyOutputIfNoGroups(),
     Meta(Keys.WritePath, new FilePath("addins/" + @doc.String(Keys.GroupKey).ToLower().Replace(" ", "-") + "/index.html")),
     Meta(Keys.RelativeFilePath, @doc.FilePath(Keys.WritePath)),
     OrderBy(@doc.String(Keys.GroupKey))

--- a/input/Shared/Section/_ExtensionMethods.cshtml
+++ b/input/Shared/Section/_ExtensionMethods.cshtml
@@ -31,7 +31,7 @@
 								miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
 							IDocument returnType = method.Get<IDocument>("ReturnType");
 							<tr>
-								<td>@Context.GetTypeLink(method, reducedName)</td>
+								<td>@Context.GetTypeLink(method, reducedName, false)</td>
 								<td>@(returnType == null ? new HtmlString(string.Empty) : Context.GetTypeLink(returnType))</td>
 								<td>
 									<div>@Html.Raw(method["Summary"])</div>

--- a/input/_DslLayout.cshtml
+++ b/input/_DslLayout.cshtml
@@ -67,11 +67,11 @@
                             <td>
                                 @if(alias.MethodAlias)
                                 {
-                                    <text>@Context.GetTypeLink(alias.Doc)</text>
+                                    <text>@Context.GetTypeLink(alias.Doc, false)</text>
                                 }
                                 else
                                 {
-                                    <text>@Context.GetTypeLink(alias.Doc, alias.Doc.String("Name"))</text>
+                                    <text>@Context.GetTypeLink(alias.Doc, alias.Doc.String("Name"), false)</text>
                                 }
                             </td>
                             <td>


### PR DESCRIPTION
This PR updates the Cake site to Wyam 1.6.0. Along with a more stable MSBuild integration, the update adds much better presentation of generic types and resolves several issues related to generic types.

Resolves #495