### PR TITLE
Update for Azure DevOps

### DIFF
--- a/input/docs/build-systems/azure-devops.md
+++ b/input/docs/build-systems/azure-devops.md
@@ -1,18 +1,18 @@
 Order: 10
-Title: Visual Studio Team Services
+Title: Azure DevOps
 ---
 
-The Cake VSTS build task makes it easy to run a Cake script directly, without having to invoke PowerShell or other command line scripts. This makes it easy even for team members that are not familiar with Cake to add or adjust parameters passed to your build scripts.
+The Cake Azure DevOps build task makes it easy to run a Cake script directly, without having to invoke PowerShell or other command line scripts. This makes it easy even for team members that are not familiar with Cake to add or adjust parameters passed to your build scripts.
 
-# 1. Install the VSTS extension
+# 1. Install the Azure DevOps extension
 
-To install the VSTS extension, go to the
+To install the Azure DevOps extension, go to the
 [Cake Build Task page](https://marketplace.visualstudio.com/items/cake-build.cake)
 on the Visual Studio Marketplace and click "Install".
 
 # 2. Add a build task
 
-Go to the `Build` section in your VSTS tenant  and create a build definition, or
+Go to the `Build` section in your Azure DevOps tenant and create a build definition, or
 select an existing one. Add a new build step by clicking the
 "Add build step..." button.
 
@@ -33,9 +33,11 @@ By default, the Cake build step (when added to a build) will try to run the `bui
 
 ![Add build step](https://raw.githubusercontent.com/cake-build/cake-vso/develop/Images/configurebuildstep.png)
 
-For those who are already using Cake making use of the [Bootstrapper file](https://cakebuild.net/docs/tutorials/setting-up-a-new-project), this is not called when using the VSO task.
+For those who are already using Cake making use of the [Bootstrapper file](https://cakebuild.net/docs/tutorials/setting-up-a-new-project), this is not called when using the Azure DevOps task.
 To use the bootstrapper file you should add a "PowerShell" or "Shell Script" task instead.
 
 ## Notes about Variables
 
-Environment Variables which are marked secret in VSTS, cannot be resolved using `EnvironmentVariable()` in a Cake script. Instead they can be passed as arguments to the build script. You can read more about this limitation in the [Visual Studio documentation under the Secret Variables section](https://www.visualstudio.com/en-us/docs/build/define/variables#SecretVariables).
+Environment Variables which are marked secret in Azure DevOps, can be default not be resolved using `EnvironmentVariable()` in a Cake script.
+They can be passed as arguments to the build script or explicitly mapped in using a YAML build definition.
+You can read more about this limitation in the [Azure DevOps documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=vsts&tabs=yaml%2Cbatch#secret-variables).


### PR DESCRIPTION
Replace branding from VSO / VSTS to Azure DevOps. Also update section about secret variables which now can be mapped using YAML build definitions.