### PR TITLE
Restored Cake.Unity addin

### DIFF
--- a/addins/Cake.Unity.yml
+++ b/addins/Cake.Unity.yml
@@ -1,0 +1,7 @@
+Name: Cake.Unity
+Repository: https://github.com/cake-contrib/Cake.Unity
+Author: Patrik Svensson
+Description: "Unity build support for Cake."
+Categories:
+- Unity
+- Gaming


### PR DESCRIPTION
Restored Cake.Unity addin because of it's update to Cake.Core 0.28 and release to NuGet.