### PR TITLE
Create an addin for BitDiffer CLI

### DIFF
--- a/addins/Cake.BitDiffer
+++ b/addins/Cake.BitDiffer
@@ -1,0 +1,10 @@
+Name: Cake.BitDiffer
+NuGet: Cake.BitDiffer
+Prerelease: true
+Assemblies:
+- "/**/Cake.BitDiffer.dll"
+Repository: https://github.com/WebDucer/Cake.BitDiffer
+Author: Eugen [WebDucer] Richter
+Description: "Cake Addin for BitDiffer command line"
+Categories:
+- BitDiffer

--- a/addins/Cake.BitDiffer.yml
+++ b/addins/Cake.BitDiffer.yml
@@ -1,6 +1,5 @@
 Name: Cake.BitDiffer
 NuGet: Cake.BitDiffer
-Prerelease: true
 Assemblies:
 - "/**/Cake.BitDiffer.dll"
 Repository: https://github.com/WebDucer/Cake.BitDiffer
@@ -8,3 +7,6 @@ Author: Eugen [WebDucer] Richter
 Description: "Cake Addin for BitDiffer command line"
 Categories:
 - BitDiffer
+- Deployment
+- Test
+- Testing


### PR DESCRIPTION
New addin for Cake. It allowes to use [BitDiffer](https://github.com/bitdiffer/bitdiffer) command line inside the Cake scripts.