### PR TITLE
Added Cake.Coverlet addin information

### DIFF
--- a/addins/Cake.Coverlet.yml
+++ b/addins/Cake.Coverlet.yml
@@ -1,0 +1,11 @@
+Name: Cake.Coverlet
+NuGet: Cake.Coverlet
+Prerelease: false
+Assemblies:
+- "/**/*.Cake.Coverlet.dll"
+Repository: https://github.com/Romanx/Cake.Coverlet
+Author: Alex McAuliffe
+Description: Cake addin that extends Cake with the ability to use Coverlet.
+Categories:
+- Code Coverage
+- Testing


### PR DESCRIPTION
The information about this addin seems to be missing on the webpage, this PR adds the necessary yml file to gather the information.