### PR TITLE
Update Wyam to 2.2.7

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
 #module nuget:?package=Cake.DotNetTool.Module&version=0.2.0
-#tool "dotnet:https://api.nuget.org/v3/index.json?package=Wyam.Tool&version=2.2.5"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=2.2.5"
+#tool "dotnet:https://api.nuget.org/v3/index.json?package=Wyam.Tool&version=2.2.7"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=2.2.7"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Yaml&version=3.0.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=YamlDotNet&version=5.2.1"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.32.0"


### PR DESCRIPTION
Bumps Wyam to the most recent version which should address the intermittent package installation failures we've started to see.

Might need to kick the PR build again in a few minutes if the NuGet gallery hasn't indexed the new Wyam version yet.