### PR TITLE
Conflicting statements w.r.t RunTarget and Setup

### DIFF
--- a/input/docs/fundamentals/setup-and-teardown.md
+++ b/input/docs/fundamentals/setup-and-teardown.md
@@ -38,4 +38,3 @@ TaskTeardown(teardownContext =>
 
 ```
 
-**NOTE:** If `RunTarget` is called before the `Setup` or `Teardown` methods are called, they won't be correctly setup and won't work.


### PR DESCRIPTION
Below statements described in the document is conflicting.

Setup will only be called if a call to `RunTarget` is made and the dependency graph is correct.
If `RunTarget` is called before the `Setup` or `Teardown` methods are called, they won't be correctly setup and won't work.

Setup will not be called until RunTarget is called and If `RunTarget` is called before the `Setup` or `Teardown` methods are called, they won't be correctly setup and won't work.

What's the correct dependency?