### PR TITLE
Updates Wyam to 2.2.8 to mitigate ongoing package installation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Note that the `Prerelease` flag can be omitted for non-prerelease packages and c
 
 The site is built using Cake (of course!). There are a number of different targets depending on what you're working on and how complete you want the generated site to be.
 
-`build -target GetSource` will download the Cake source code that the generation process uses to create the "API" section.
+`build --target=GetSource` will download the Cake source code that the generation process uses to create the "API" section.
 
-`build -target GetAddinPackages` will download new NuGet packages for all specified addins. These packages are used to create the "Reference" and "Addins" sections.
+`build --target=GetAddinPackages` will download new NuGet packages for all specified addins. These packages are used to create the "Reference" and "Addins" sections.
 
-`build -target GetArtifacts` will download both the Cake source code and the addin NuGet packages.
+`build --target=GetArtifacts` will download both the Cake source code and the addin NuGet packages.
 
-`build -target Build` will run a complete build, downloading new copies of Cake source code and addin NuGet packages. Note that due to the number of addins and the complexity of generating complete API documentation, the site generation may take a while (sometimes as long as 20 minutes).
+`build --target=Build` will run a complete build, downloading new copies of Cake source code and addin NuGet packages. Note that due to the number of addins and the complexity of generating complete API documentation, the site generation may take a while (sometimes as long as 20 minutes).
 
-`build -target Preview` will run a build but *will not* download Cake source code or NuGet packages. This lets you shorten the build cycle by avoiding the time to obtain those resources if you've already downloaded them, or to bypass them altogether if you're just working on something like general documentation pages. This target will also launch a preview server to look at the generated site from a local web browser. The URL of the generated preview site is `http://localhost:5080/`.
+`build --target=Preview` will run a build but *will not* download Cake source code or NuGet packages. This lets you shorten the build cycle by avoiding the time to obtain those resources if you've already downloaded them, or to bypass them altogether if you're just working on something like general documentation pages. This target will also launch a preview server to look at the generated site from a local web browser. The URL of the generated preview site is `http://localhost:5080/`.

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
 #module nuget:?package=Cake.DotNetTool.Module&version=0.2.0
-#tool "dotnet:https://api.nuget.org/v3/index.json?package=Wyam.Tool&version=2.2.7"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=2.2.7"
+#tool "dotnet:https://api.nuget.org/v3/index.json?package=Wyam.Tool&version=2.2.8"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=2.2.8"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Yaml&version=3.0.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=YamlDotNet&version=5.2.1"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.32.0"


### PR DESCRIPTION
The new Azure Pipelines images with latest VS break Wyam package installation due to outdated NuGet client library incompatibilities. This updates Wyam to avoid those errors.

I also updated the readme to account to argument differences now that we're building with `Cake.Tool`.