### PR TITLE
Adding yml for new addin - Cake.SonarResults

### DIFF
--- a/addins/Cake.SonarResults.yml
+++ b/addins/Cake.SonarResults.yml
@@ -1,0 +1,9 @@
+Name: Cake.SonarResults
+NuGet: Cake.SonarResults
+Assemblies:
+- "/**/Cake.SonarResults.dll"
+Repository: https://github.com/rhtnr/Cake.SonarResults
+Author: Rohit Nair
+Description: Cake Addin to break the build after running the sonnar-scanner tool.
+Categories:
+- code quality


### PR DESCRIPTION
Adding yml for new addin - Cake.SonarResults 
Addin can break builds if SonarQube analysis fails after running a SonarQube analysis