### PR TITLE
Small improvements on wording on homepage

### DIFF
--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -29,19 +29,19 @@ NoGutter: true
 
             <h3>Cross runtime</h3>
             <p>
-                Cake runs on .NET, .NET Core and Mono.
+                Cake runs on .NET Core, .NET Framework and Mono.
             </p>
 
             <h3>Reliable</h3>
             <p>
                 Regardless if you're building on your own machine, or building on a CI system such as AppVeyor, Azure DevOps,
-                TeamCity, TFS or Jenkins, Cake is built to behave in the same way.
+                TeamCity or Jenkins, Cake is built to behave in the same way.
             </p>
 
             <h3>Batteries included</h3>
             <p>
                 Cake supports the most common tools used during builds such as MSBuild, .NET Core CLI, MSTest, xUnit, NUnit,
-                NuGet, ILMerge, WiX and SignTool out of the box.
+                NuGet, ILMerge, WiX and SignTool out of the box and many more through an ever growing list of <a href="/addins">addins</a>.
             </p>
 
             <h3>Open source</h3>


### PR DESCRIPTION
Some small improvements on wording on homepage:

- Put .NET Core first and make clear that .NET means .NET Framework, compared to .NET 5
- Get rid of TFS, since it is now also called Azure DevOps
- Mention addin eco-system