### PR TITLE
Fix issue with documentation

### DIFF
--- a/input/docs/getting-started/setting-up-a-new-project.md
+++ b/input/docs/getting-started/setting-up-a-new-project.md
@@ -60,7 +60,7 @@ Task("Test")
     .IsDependentOn("Build")
     .Does(() =>
 {
-    DotNetCoreTest("./src/Example.sln", new DotNetCoreBuildSettings
+    DotNetCoreTest("./src/Example.sln", new DotNetCoreTestSettings
     {
         Configuration = configuration,
         NoBuild = true,


### PR DESCRIPTION
I get this error when I copy and paste the text: 

`Error: Error(s) occurred when compiling build script:
E:/dev/code/pmc-orgchart/build.cake(25,45): error CS1503: Argument 2: cannot convert from 'Cake.Common.Tools.DotNetCore.Build.DotNetCoreBuildSettings' to 'Cake.Common.Tools.DotNetCore.Test.DotNetCoreTestSettings'`

And so the change is intended to fix this.