### PR TITLE
Add documentation for Cake Frosting

### DIFF
--- a/input/docs/getting-started/bootstrapping-scripts.md
+++ b/input/docs/getting-started/bootstrapping-scripts.md
@@ -51,6 +51,66 @@ By convention this will execute the build script named `build.cake`.
 You can override this behavior by additionally passing the name of the build script.
 :::
 
+# Bootstrapping for Cake Frosting
+
+When creating a new [Cake Frosting](https://github.com/cake-build/frosting) project from the template default bootstrapping scripts for Windows, macOS and Linux are created.
+
+:::{.alert .alert-info}
+The following instructions require .NET Core 3.1.301 or newer.
+You can find the SDK at https://dotnet.microsoft.com/download
+:::
+
+## Setup
+
+To create a new [Cake Frosting](https://github.com/cake-build/frosting) project you need to install the Frosting template:
+
+```
+dotnet new --install Cake.Frosting.Template
+```
+
+Create a new Frosting project:
+
+```
+dotnet new cakefrosting
+```
+
+This will create the Cake Frosting build script and bootstrapping scripts.
+
+## Running build script
+
+
+Run the build script:
+
+<ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" href="#windows">Windows</a></li>
+    <li><a data-toggle="tab" href="#linux">Linux</a></li>
+    <li><a data-toggle="tab" href="#macos">MacOS</a></li>
+</ul>
+
+<div class="tab-content">
+    <div id="windows" class="tab-pane fade in active">
+        <p>
+            <code class="language-powershell hljs">
+               ./build.ps1
+            </code>
+        </p>
+    </div>
+    <div id="linux" class="tab-pane fade">
+        <p>
+            <code class="language-bash hljs">
+               build.sh
+            </code>
+        </p>
+    </div>
+    <div id="macos" class="tab-pane fade">
+        <p>
+            <code class="language-bash hljs">
+               build.sh
+            </code>
+        </p>
+    </div>
+</div>
+
 # Bootstrapping for Cake runner for .NET Framework
 
 ## Getting the bootstrapper
@@ -154,4 +214,3 @@ operating system from below:
 
 The bootstrapper that you can get directly from [cakebuild.net](https://cakebuild.net) is intended as a starting point for what can be done.
 It is the developer's discretion to extend the bootstrapper to solve for your own requirements.
-

--- a/input/docs/getting-started/running-cake-scripts.md
+++ b/input/docs/getting-started/running-cake-scripts.md
@@ -13,6 +13,16 @@ The [Cake.Tool](https://www.nuget.org/packages/Cake.Tool) NuGet package, is a .N
 
 For bootstrapping .NET Core Tool see [Bootstrapping .NET Core Tool](bootstrapping-scripts#bootstrapping-for.net-core-tool).
 
+# Cake Frosting
+
+[Cake.Frosting](https://github.com/cake-build/frosting) is a .NET Core host which allows you to write your build scripts as a console application.
+
+:::{.alert .alert-info}
+A console application has the advantage of full IDE support, like IntelliSense, refactoring and debugging.
+:::
+
+For bootstrapping Cake Frosting see [Bootstrapping for Cake Frosting](bootstrapping-scripts#bootstrapping-for-cake-frosting).
+
 # Cake runner for .NET Framework
 
 The [Cake](https://www.nuget.org/packages/Cake) NuGet package is a runner requiring [.NET Framework 4.6.1](https://www.microsoft.com/net/download/dotnet-framework/net461)

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -32,6 +32,11 @@ NoGutter: true
                 Cake runs on .NET Core, .NET Framework and Mono.
             </p>
 
+            <h3>Flexible</h3>
+            <p>
+                Cake can be used with scripts or as simple console applications with full IDE integration.
+            </p>
+
             <h3>Reliable</h3>
             <p>
                 Regardless if you're building on your own machine, or building on a CI system such as AppVeyor, Azure DevOps,


### PR DESCRIPTION
Add documentation for Cake Frosting. Lists it as a possible runner, instruction how to setup / run.

Also adds an additional point to the homepage to highlight the flexibility Cake provides.