### PR TITLE
Add documentation for Cake.CoreCLR IntelliSense support in VS Code

### DIFF
--- a/input/docs/editors/vscode/intellisense.md
+++ b/input/docs/editors/vscode/intellisense.md
@@ -216,8 +216,102 @@ To enable IntelliSense support in Visual Studio Code follow these steps:
     </div>
     <div id="core" class="tab-pane fade">
         <p>
-            IntelliSense in Visual Studio Code is not supported for the Cake runner for .NET Core.
+            IntelliSense support for <code>.cake</code> files is provided through the
+            <a href="https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp">C# extension for Visual Studio Code</a>,
+            along with <a href="https://github.com/cake-build/bakery">Cake.Bakery</a>.
         </p>
+        <ol>
+            <li>
+                Open Visual Studio Code to the folder that you have a Cake file in.
+            </li>
+            <li>
+                <p>
+                    Install <a href="https://marketplace.visualstudio.com/items/cake-build.cake-vscode">Cake extension for Visual Studio Code</a>.
+                    Make sure at least version 0.10.1 is installed.
+                </p>
+                <div class="alert alert-info">
+                    <p>
+                        For instructions how to install an extension in Visual Studio Code see
+                        <a href="https://code.visualstudio.com/docs/editor/extension-gallery">Extension Marketplace documentation</a>.
+                    </p>
+                </div>
+            </li>
+            <li>
+                <p>
+                    Install <a href="https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp">C# extension for Visual Studio Code</a>.
+                    Make sure at least version 1.13.0 is installed.
+                </p>
+                <div class="alert alert-info">
+                    <p>
+                        For instructions how to install an extension in Visual Studio Code see
+                        <a href="https://code.visualstudio.com/docs/editor/extension-gallery">Extension Marketplace documentation</a>.
+                    </p>
+                </div>
+            </li>
+            <li>
+                <p>
+                    Make sure that <a href="https://www.nuget.org/packages/Cake.CoreCLR/" target="_blank">Cake.CoreCLR</a> is installed in your <code>tools</code> folder.
+                    We recommend v0.22.0 or later, otherwise your addins will be installed twice.
+                    The easiest way to do this is to run your bootstrapping file (e.g. <code>.\build.ps1</code>).
+                </p>
+                <div class="alert alert-warning">
+                    <p>
+                        For Cake.Bakery <code>Cake.Core.dll</code> and <code>Cake.dll</code> need to be available in the same folder.
+                        Installation of Cake through <a href="https://chocolatey.org/packages/cake.portable" target="_blank">Cake.Portable Chocolatey package</a>
+                        therefore won't support IntelliSense.
+                    </p>
+                </div>
+            </li>
+            <li>
+                <p>Install <a href="https://github.com/cake-build/bakery">Cake.Bakery</a> using any of the following options:</p>
+                <ul>
+                    <li>
+                        <p>
+                            Using <a href="https://marketplace.visualstudio.com/items/cake-build.cake-vscode">Cake extension for Visual Studio Code</a>:
+                        </p>
+                        <ul>
+                            <li>Open command palette (<code>Ctrl+Shift+P</code>)</li>
+                            <li>Type <code>Cake</code></li>
+                            <li>Select <code>Install intellisense support</code> command.</li>
+                        </ul>
+                    </li>
+                    <li>
+                        <p>
+                            On Windows using <a href="https://chocolatey.org/">Chocolatey</a>:
+                        </p>
+                        <pre><code class="language-cmd">choco install cake-bakery.portable</code></pre>
+                    </li>
+                    <li>
+                        <p>
+                            Download <a href="https://github.com/cake-build/bakery/releases">Release ZIP</a>,
+                            extract it and add it to <code>PATH</code> environment variable.
+                        </p>
+                        <div class="alert alert-info">
+                            <p>
+                                If you want to install Cake.Bakery outside of the <code>PATH</code> environment variable you can specify
+                                the path to <code>Cake.Bakery.exe</code> using the
+                                <a href="https://github.com/OmniSharp/omnisharp-roslyn/wiki/Configuration-Options" target="_blank">OmniSharp Configuration System</a>.
+                            </p>
+                            <p>
+                                Create a file called <code>omnisharp.json</code> in <code>%USERPROFILE%/.omnisharp/</code>
+                                (<code>~/.omnisharp/</code> if you are on Linux/macOS) with the following content
+                                (replace <code>&lt;custom_path&gt;</code> with the path to Cake.Bakery.):
+                            </p>
+<pre><code class="language-json">
+{
+  "cake": {
+    "bakeryPath": "&lt;custom_path&gt;/Cake.Bakery/tools/Cake.Bakery.exe"
+  }
+}
+</code></pre>
+                        </div>
+                    </li>
+                </ul>
+            </li>
+            <li>
+                Restart Visual Studio Code.
+            </li>
+        </ol>
     </div>
 </div>
 

--- a/input/docs/getting-started/running-cake-scripts.md
+++ b/input/docs/getting-started/running-cake-scripts.md
@@ -9,7 +9,7 @@ There are different runners available for running Cake scripts.
 | [.NET Core Tool] | .NET Core 2.1 | <span class="glyphicon glyphicon-ok" style="color:green"></span> | <span class="glyphicon glyphicon-ok" style="color:orange"></span> [[1]](#1) |
 | [Cake Frosting] | .NET Framework 4.6.1 or .NET Core 3.1 | <span class="glyphicon glyphicon-ok" style="color:green"></span> | <span class="glyphicon glyphicon-ok" style="color:green"></span> |
 | [Cake runner for .NET Framework] | .NET Framework 4.6.1 or Mono 5.0.12 | <span class="glyphicon glyphicon-ok" style="color:green"></span> | <span class="glyphicon glyphicon-ok" style="color:orange"></span> [[1]](#1) |
-| [Cake runner for .NET Core] | .NET Core 2.0 | <span class="glyphicon glyphicon-remove" style="color:red"></span> | <span class="glyphicon glyphicon-remove" style="color:red"></span> |
+| [Cake runner for .NET Core] | .NET Core 2.0 | <span class="glyphicon glyphicon-remove" style="color:red"></span> | <span class="glyphicon glyphicon-ok" style="color:orange"></span> [[1]](#1) |
 
 <a id="1"></a>
 [1]: Limited support in Visual Studio Code. See [IntelliSense in Visual Studio Code]


### PR DESCRIPTION
IntelliSense is in the meantime supported for Cake.CoreCLR. Update documentation and add instructions how to enable in Visual Studio Code.