### PR TITLE
Restructure configuration pages

### DIFF
--- a/input/docs/running-builds/configuration/default-configuration-values.md
+++ b/input/docs/running-builds/configuration/default-configuration-values.md
@@ -1,10 +1,12 @@
-Order: 50
-RedirectFrom: docs/fundamentals/default-configuration-values
+Order: 20
+RedirectFrom:
+  - docs/running-builds/default-configuration-values
+  - docs/fundamentals/default-configuration-values
 ---
 
 The following shows all of the configuration options currently available within Cake, as well as their default values.
 
-Refer to [Configuration](/docs/fundamentals/configuration) for instructions on using a config file.
+Refer to [set configuration values](/docs/running-builds/configuration/set-configuration-values) for instructions on using a config file.
 
 # NuGet Download Url
 

--- a/input/docs/running-builds/configuration/index.cshtml
+++ b/input/docs/running-builds/configuration/index.cshtml
@@ -1,0 +1,8 @@
+Order: 40
+---
+
+<p>
+    Cake can be configured so that you can control the internals of how Cake operates during the build.
+</p>
+
+@Html.Partial("_ChildPages")

--- a/input/docs/running-builds/configuration/set-configuration-values.md
+++ b/input/docs/running-builds/configuration/set-configuration-values.md
@@ -1,5 +1,6 @@
-Order: 40
-RedirectFrom: docs/fundamentals/configuration
+Order: 10
+RedirectFrom:
+  - docs/fundamentals/configuration
 ---
 
 Cake supports the concept of external configuration, to allow the internals of how Cake operates to be controlled, based on a specified priority, from either:
@@ -14,7 +15,11 @@ Cake supports the concept of external configuration, to allow the internals of h
 
 As an example of where this overridable configuration can be applied, let's look at how Cake determines where to download NuGet packages from. By default, it does this by downloading the nuget packages user configured sources.  However, it may be necessary (for example, when running in an offline/local environment) to download these nuget packages from an alternative source.  This is where the Cake Configuration comes into play.
 
+### Environment Variable
+
 By creating an Environment variable with the name of `CAKE_NUGET_SOURCE` and setting the value to the URL that is required, Cake will use this alternative download source, rather than the defaults.
+
+### Configuration File
 
 Alternatively, you can create a `cake.config` file with the following content:
 
@@ -30,6 +35,8 @@ Source=https://mycustomurl
 Specifying a configuration value within a configuration file will override the same configuration value stored within an equivalent Environment variable.
 
 **NOTE:** This configuration file should be located in the same directory as your `build.cake` file.
+
+### Command Line
 
 Finally, you can specify an input parameter directly to the Cake.exe, in the following format:
 
@@ -49,4 +56,4 @@ cake.exe --nuget_source=http://mycustomurl;http://myothercustomurl
 
 <br />
 
-Refer to the [default configuration values](/docs/fundamentals/default-configuration-values) for a list of all the available configuration options.
+Refer to the [default configuration values](/docs/running-builds/configuration/default-configuration-values) for a list of all the available configuration options.


### PR DESCRIPTION
@pascalberger:

> I would suggest to have docs/configuration/ giving a brief introduction to configuration for Cake, plus the list of sub-pages (like e.g. done at https://cakebuild.net/docs/extending/modules/). This would be in the index.cshtml file. I think the most part of docs/fundamentals/configuration.md can be moved to something like docs/configuration/set-configuration-values.md.

Part of #907 