### PR TITLE
(GH-153) Add search box

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Categories:
 
 Note that the `Prerelease` flag can be omitted for non-prerelease packages and controls whether NuGet will attempt to download a prerelease version of the package when generating the site.
 
+## Search
+
+Search uses [Algolia DocSearch](https://docsearch.algolia.com/) as backend.
+Configuration for crawler is available at https://github.com/algolia/docsearch-configs/blob/master/configs/cakeissues.json.
+
 ## Building
 
 The site is built using Cake (of course!). There are a number of different targets depending on what you're working on and how complete you want the generated site to be.

--- a/input/_Bottom.cshtml
+++ b/input/_Bottom.cshtml
@@ -1,3 +1,14 @@
+<!-- Search -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript">
+    docsearch({
+        apiKey: '7c45d75e5cd2fddcb761d830d2b8ee27',
+        indexName: 'cakebuild',
+        inputSelector: '#search-query',
+        debug: false
+    });
+</script>
+
 <!-- Gitter -->
 <script>
     ((window.gitter = {}).chat = {}).options = {

--- a/input/_Head.cshtml
+++ b/input/_Head.cshtml
@@ -1,1 +1,2 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 <script type="text/javascript" src="/assets/js/anchor.min.js"></script>

--- a/input/_Navbar.cshtml
+++ b/input/_Navbar.cshtml
@@ -1,3 +1,7 @@
+<div class="navbar-right navbar-form">
+    <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off" autofocus>
+</div>
+
 @{
     List<Tuple<string, string>> pages = new List<Tuple<string, string>>
     {

--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -3,6 +3,24 @@ div.tab-pane {
   padding-top: 15px;
 }
 
+// Search box
+#navbar-collapse, #navbar-collapse nav {
+  width: 100%;
+}
+
+.navbar-nav {
+  float: none;
+}
+
+.navbar-right {
+  margin-right: 15px;
+}
+
+@media (max-width: 767px) {
+  .navbar-right {
+      margin-left: 0px;
+  }
+}
 // Giter button
 .bottom-footer {
 	margin-bottom: 40px !important;  // Make room for Gitter buttons


### PR DESCRIPTION
Add search box using Algolia DocSearch as indexing engine.

![image](https://user-images.githubusercontent.com/2190718/95599698-b2017200-0a51-11eb-9dc0-441ce8db23f5.png)

Currenty indexed are the following areas:

- Blog
- Documentation
- Reference
- Addin
- FAQ

API part is currently not indexed. I currently don't see a way to index them properly with the way how API pages are structured (multiple headings as H1, title containing not only name but also type). My suggestion would be to merge it like this and create an issue for API indexing (maybe something which we only can fix when migrating to Statiq)

Fixes #153 