### PR TITLE
Link to GitHub organization

### DIFF
--- a/input/_Navbar.cshtml
+++ b/input/_Navbar.cshtml
@@ -11,7 +11,7 @@
         Tuple.Create("Addins", Context.GetLink("addins")),
         Tuple.Create("API", Context.GetLink("api")),
         Tuple.Create("FAQ", Context.GetLink("faq")),
-        Tuple.Create("<i class=\"fa fa-github\"></i> Source", "https://github.com/cake-build/cake")
+        Tuple.Create("<i class=\"fa fa-github\"></i> Source", "https://github.com/cake-build")
     };
     foreach(Tuple<string, string> p in pages)
     {


### PR DESCRIPTION
The "official" Cake ecosystem consists of more than Cake itself. Also integrations for editors and build servers, etc. We should therefore link to the GitHub organization which lists all of them instead of the Cake repo itself.