### PR TITLE
Add "Star on GitHub" button to landing page

### DIFF
--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -9,6 +9,7 @@ NoGutter: true
         <p>Cake (C# Make) is a cross-platform build automation system with a C# DSL for tasks such as compiling code, copying files and folders, running unit tests, compressing files and building NuGet packages.</p>
         <p>
             <a class="btn btn-primary btn-lg" href="/docs/getting-started/setting-up-a-new-project" role="button">Get Started &raquo;</a>
+            <a class="btn btn-primary btn-lg" href="https://github.com/cake-build/cake" role="button" target="_blank">⭐ Star on GitHub</a>
         </p>
     </div>
 </div>


### PR DESCRIPTION
We recently changed source code link in the navigation to the organization. While this makes sense to give users an overview about all source code repos, it is also helpful to have people starring the main repo, since stars are often used for measuring the popularity of a project.

This adds a "Star on GitHub" button to the landing page:

![image](https://user-images.githubusercontent.com/2190718/95663601-df791900-0b40-11eb-94ed-8350926701c8.png)
