### PR TITLE
(GH-1115) Add info that preprocessor directives are not available in Frosting

### DIFF
--- a/input/docs/writing-builds/preprocessor-directives.md
+++ b/input/docs/writing-builds/preprocessor-directives.md
@@ -5,6 +5,10 @@ RedirectFrom: docs/fundamentals/preprocessor-directives
 Cake scripts have support for pre-processor line directives, which run before the script is executed.
 These can be used to reference other scripts, assemblies, namespaces and more.
 
+:::{.alert .alert-info}
+Preprocessor directives are not required or available when running with [Cake Frosting](/docs/running-builds/runners/cake-frosting).
+:::
+
 # Add-in directive
 The add-in directive is used to install and reference assemblies using NuGet.
 


### PR DESCRIPTION
Add info that preprocessor directives are not available in Frosting

![image](https://user-images.githubusercontent.com/2190718/95686477-4dcfe100-0bfe-11eb-936d-c172ddbf848e.png)

Fixes #1115 