### PR TITLE
(GH-1083) Add link to OpenCollective

### DIFF
--- a/input/_Navbar.cshtml
+++ b/input/_Navbar.cshtml
@@ -11,6 +11,7 @@
         Tuple.Create("Addins", Context.GetLink("addins")),
         Tuple.Create("API", Context.GetLink("api")),
         Tuple.Create("FAQ", Context.GetLink("faq")),
+        Tuple.Create("<i class=\"fa fa-heart\"></i> Support Us", "https://opencollective.com/cake"),
         Tuple.Create("<i class=\"fa fa-github\"></i> Source", "https://github.com/cake-build")
     };
     foreach(Tuple<string, string> p in pages)


### PR DESCRIPTION
Add link to OpenCollective to main navigation:

![image](https://user-images.githubusercontent.com/2190718/95689524-a52b7c80-0c11-11eb-9c1a-053e7f63bd1b.png)

Fixes #1083 