### PR TITLE
Fix formatting of code blocks

### DIFF
--- a/input/docs/getting-started/setting-up-a-new-project.md
+++ b/input/docs/getting-started/setting-up-a-new-project.md
@@ -16,13 +16,13 @@ on .NET Core 3.0 and newer.
 
 Make sure to have a tool manifest available in your repository or create one using the following command:
 
-```shell
+```powershell
 dotnet new tool-manifest
 ```
 
 Install Cake as a local tool using the `dotnet tool` command:
 
-```shell
+```powershell
 dotnet tool install Cake.Tool --version x.y.z
 ```
 

--- a/input/docs/integrations/editors/vscode/intellisense.md
+++ b/input/docs/integrations/editors/vscode/intellisense.md
@@ -66,7 +66,7 @@ To enable IntelliSense support in Visual Studio Code follow these steps:
                         <p>
                             On Windows using <a href="https://chocolatey.org/">Chocolatey</a>:
                         </p>
-                        <pre><code class="language-cmd">choco install cake-bakery.portable</code></pre>
+                        <pre><code class="language-cmd hljs">choco install cake-bakery.portable</code></pre>
                     </li>
                     <li>
                         <p>
@@ -84,7 +84,7 @@ To enable IntelliSense support in Visual Studio Code follow these steps:
                                 (<code>~/.omnisharp/</code> if you are on Linux/macOS) with the following content
                                 (replace <code>&lt;custom_path&gt;</code> with the path to Cake.Bakery.):
                             </p>
-<pre><code class="language-json">
+<pre><code class="language-json hljs">
 {
   "cake": {
     "bakeryPath": "&lt;custom_path&gt;/Cake.Bakery/tools/Cake.Bakery.exe"
@@ -181,7 +181,7 @@ To enable IntelliSense support in Visual Studio Code follow these steps:
                         <p>
                             On Windows using <a href="https://chocolatey.org/">Chocolatey</a>:
                         </p>
-                        <pre><code class="language-cmd">choco install cake-bakery.portable</code></pre>
+                        <pre><code class="language-cmd hljs">choco install cake-bakery.portable</code></pre>
                     </li>
                     <li>
                         <p>
@@ -199,7 +199,7 @@ To enable IntelliSense support in Visual Studio Code follow these steps:
                                 (<code>~/.omnisharp/</code> if you are on Linux/macOS) with the following content
                                 (replace <code>&lt;custom_path&gt;</code> with the path to Cake.Bakery.):
                             </p>
-<pre><code class="language-json">
+<pre><code class="language-json hljs">
 {
   "cake": {
     "bakeryPath": "&lt;custom_path&gt;/Cake.Bakery/tools/Cake.Bakery.exe"
@@ -280,7 +280,7 @@ To enable IntelliSense support in Visual Studio Code follow these steps:
                         <p>
                             On Windows using <a href="https://chocolatey.org/">Chocolatey</a>:
                         </p>
-                        <pre><code class="language-cmd">choco install cake-bakery.portable</code></pre>
+                        <pre><code class="language-cmd hljs">choco install cake-bakery.portable</code></pre>
                     </li>
                     <li>
                         <p>
@@ -298,7 +298,7 @@ To enable IntelliSense support in Visual Studio Code follow these steps:
                                 (<code>~/.omnisharp/</code> if you are on Linux/macOS) with the following content
                                 (replace <code>&lt;custom_path&gt;</code> with the path to Cake.Bakery.):
                             </p>
-<pre><code class="language-json">
+<pre><code class="language-json hljs">
 {
   "cake": {
     "bakeryPath": "&lt;custom_path&gt;/Cake.Bakery/tools/Cake.Bakery.exe"

--- a/input/docs/running-builds/runners/cake-frosting.md
+++ b/input/docs/running-builds/runners/cake-frosting.md
@@ -47,13 +47,13 @@ You can find the SDK at https://dotnet.microsoft.com/download
 
 To create a new [Cake Frosting](https://github.com/cake-build/frosting) project you need to install the Frosting template:
 
-```
+```powershell
 dotnet new --install Cake.Frosting.Template
 ```
 
 Create a new Frosting project:
 
-```
+```powershell
 dotnet new cakefrosting
 ```
 

--- a/input/docs/running-builds/runners/dotnet-core-tool.md
+++ b/input/docs/running-builds/runners/dotnet-core-tool.md
@@ -35,13 +35,13 @@ If you have .NET Core Tool already available in your environment you can skip th
 
 Make sure to have a tool manifest available in your repository or create one using the following command:
 
-```shell
+```powershell
 dotnet new tool-manifest
 ```
 
 Install Cake as a local tool using the `dotnet tool` command:
 
-```shell
+```powershell
 dotnet tool install Cake.Tool --version x.y.z
 ```
 
@@ -49,13 +49,13 @@ dotnet tool install Cake.Tool --version x.y.z
 
 Make sure tools are restored:
 
-```shell
+```powershell
 dotnet tool restore
 ```
 
 Once installed, you can launch Cake using the .NET CLI:
 
-```shell
+```powershell
 dotnet cake
 ```
 


### PR DESCRIPTION
Currently not all code blocks are formatted equally. Some contain the `hljs` class, and thus additional padding, others not. This PR changes language for all code blocks to an identifiert that results in a code block with the `hljs` class applied.

For HTML code blocks the class is applied manually. And in a few cases language was currently missing completely, resulting in wrong syntax highlighting (e.g. `cpp` for `dotnet new`)