### PR TITLE
Remove redundant heading

### DIFF
--- a/input/docs/integrations/editors/vscode/resources.md
+++ b/input/docs/integrations/editors/vscode/resources.md
@@ -4,8 +4,6 @@ Description: Resources about Visual Studio Code support
 RedirectFrom: docs/editors/vscode/resources
 ---
 
-# Visual Studio Code resources
-
 There is a playlist of videos showing off the new features in each release of the [Cake extension for Visual Studio Code] here:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PL84yg23i9GBg7_7an5Qbo0Qllg-l2e-q-" frameborder="0" gesture="media" allowfullscreen></iframe>

--- a/input/docs/integrations/editors/vscode/snippets.md
+++ b/input/docs/integrations/editors/vscode/snippets.md
@@ -4,8 +4,6 @@ Description: Support for code snippets
 RedirectFrom: docs/editors/vscode/snippets
 ---
 
-# Visual Studio Code snippets
-
 <ul class="nav nav-tabs">
     <li class="active"><a data-toggle="tab" href="#tool">.NET Core Tool</a></li>
     <li><a data-toggle="tab" href="#frosting">Cake Frosting</a></li>


### PR DESCRIPTION
Remove heading which is redundant to page title, since it doesn't provide any additional value and has negative impact on search results (duplicate entry when searching for the topic)