### PR TITLE
Use a boolean env variable to enable cache purging

### DIFF
--- a/deploy.cake
+++ b/deploy.cake
@@ -21,7 +21,7 @@ Setup<Deployment>(
               value => value.Value,
               StringComparer.OrdinalIgnoreCase);
 
-    var shouldPurgeCloudFlareCache = context.HasEnvironmentVariable("SHOULD_PURGE_CLOUDFLARE_CACHE");
+    var shouldPurgeCloudFlareCache = context.EnvironmentVariable("SHOULD_PURGE_CLOUDFLARE_CACHE", false);
 
     var cloudflareAuthEmail = context.EnvironmentVariable("CLOUDFLARE_AUTH_EMAIL");
 


### PR DESCRIPTION
Use a boolean env variable to enable cache purging instead of just the existance of an env variable.

This allow to have a variable defined in the Azure Pipeline which can be set on a release.