### PR TITLE
Move /addins to /extensions

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -26,7 +26,7 @@ Pipelines.InsertAfter("Addins", "AddinCategories",
         Documents("Addins")
     )
         .WithEmptyOutputIfNoGroups(),
-    Meta(Keys.WritePath, new FilePath("addins/" + @doc.String(Keys.GroupKey).ToLower().Replace(" ", "-") + "/index.html")),
+    Meta(Keys.WritePath, new FilePath("extensions/" + @doc.String(Keys.GroupKey).ToLower().Replace(" ", "-") + "/index.html")),
     Meta(Keys.RelativeFilePath, @doc.FilePath(Keys.WritePath)),
     OrderBy(@doc.String(Keys.GroupKey))
 );

--- a/input/_Navbar.cshtml
+++ b/input/_Navbar.cshtml
@@ -8,7 +8,7 @@
         Tuple.Create("Blog", Context.GetLink("blog")),
         Tuple.Create("Documentation", Context.GetLink("docs")),
         Tuple.Create("Reference", Context.GetLink("dsl")),
-        Tuple.Create("Addins", Context.GetLink("addins")),
+        Tuple.Create("Extensions", Context.GetLink("extensions")),
         Tuple.Create("API", Context.GetLink("api")),
         Tuple.Create("<i class=\"fa fa-heart\"></i> Support Us", "https://opencollective.com/cake"),
         Tuple.Create("<i class=\"fa fa-github\"></i> Source", "https://github.com/cake-build")

--- a/input/docs/index.cshtml
+++ b/input/docs/index.cshtml
@@ -9,7 +9,7 @@ Title: Documentation
 </p>
 <p>
     Out of the box it contains a number of different <a href="/dsl">aliases</a> to allow you to quickly orchestrate your build process, such as MSBuild, DotNet Core CLI, NuGet, and Chocolatey.
-    In addition, there are over 280 community driven <a href="/addins">addins</a> which allow you to perform other build tasks.
+    In addition, there are over 280 community driven <a href="/extensions">addins and modules</a> which allow you to perform other build tasks.
 </p>
 <p>
     Extensions which enhance usability while working with Cake builds are also available for <a href="/docs/integrations/editors">editors and IDE's</a> as well as <a href="/docs/integrations/build-systems">build systems</a>.

--- a/input/extensions/index.cshtml
+++ b/input/extensions/index.cshtml
@@ -1,10 +1,11 @@
 Title: Addins
 NoSidebar: false
+RedirectFrom: addins
 ---
-@section Infobar {	
+@section Infobar {
 }
 
-@section Sidebar {    
+@section Sidebar {
     @Html.Partial("_AddinsSidebar")
 }
 

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -57,7 +57,7 @@ NoGutter: true
             <h3 class="no-anchor">Batteries included</h3>
             <p>
                 Cake supports the most common tools used during builds such as MSBuild, .NET Core CLI, MSTest, xUnit, NUnit,
-                NuGet, ILMerge, WiX and SignTool out of the box and many more through an ever growing list of <a href="/addins">addins</a>.
+                NuGet, ILMerge, WiX and SignTool out of the box and many more through an ever growing list of <a href="/extensions">addins and modules</a>.
             </p>
         </div>
         <div class="col-sm-4">


### PR DESCRIPTION
First (small) step on the way to design sketched at #1096. Current addin page should be able to host other extension (models, recipe scripts) and should therefore be available at `/extensions` instead of `/addins`.