### PR TITLE
(GH-927) Show aliases on addin page

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -10,6 +10,7 @@ Settings[DocsKeys.IncludeDateInPostPath] = true;
 Settings[DocsKeys.BlogAtomPath] = "blog/feed/atom/index.xml";
 Settings[DocsKeys.BlogRssPath] = "blog/feed/rss/index.xml";
 
+// Reads addin metadata
 Pipelines.InsertBefore(Docs.Code, "Addins",
     ReadFiles("../addins/*.yml"),
     Yaml(),
@@ -26,22 +27,31 @@ Pipelines.InsertBefore(Docs.Code, "Addins",
     Meta(DocsKeys.NoSidebar, true)
 );
 
-Pipelines.InsertAfter(Docs.Api, "DslAliases",
-    GroupByMany(@doc.DocumentList(CodeAnalysisKeys.Attributes)
-        .Where(attr => attr.String(CodeAnalysisKeys.Name) == "CakeAliasCategoryAttribute")
-        .Select(attr => attr.Get<Microsoft.CodeAnalysis.AttributeData>(CodeAnalysisKeys.AttributeData).ConstructorArguments.FirstOrDefault().Value)
-        .Distinct(),
-        Documents(Docs.Api),
-        Where(@doc.String(CodeAnalysisKeys.Kind) == "NamedType"
-            && @doc.DocumentList(CodeAnalysisKeys.Attributes)
-                .Any(attr => attr.String(CodeAnalysisKeys.Name) == "CakeAliasCategoryAttribute")
-        )
+// Read all classes containing aliases from API documentation
+Pipelines.InsertAfter(Docs.Api, "Aliases",
+    Documents(Docs.Api),
+    Where(
+        @doc.String(CodeAnalysisKeys.Kind) == "NamedType"
+        && @doc.DocumentList(CodeAnalysisKeys.Attributes)
+            .Any(attr => attr.String(CodeAnalysisKeys.Name) == "CakeAliasCategoryAttribute")
+    )
+);
+
+// Prepares aliases classes for reference page by grouping them by category.
+Pipelines.InsertAfter("Aliases", "DslAliases",
+    GroupByMany(
+        @doc.DocumentList(CodeAnalysisKeys.Attributes)
+            .Where(attr => attr.String(CodeAnalysisKeys.Name) == "CakeAliasCategoryAttribute")
+            .Select(attr => attr.Get<Microsoft.CodeAnalysis.AttributeData>(CodeAnalysisKeys.AttributeData).ConstructorArguments.FirstOrDefault().Value)
+            .Distinct(),
+        Documents("Aliases")
     ),
     Meta(Keys.WritePath, new FilePath("dsl/" + @doc.String(Keys.GroupKey).ToLower().Replace(" ", "-") + "/index.html")),
     Meta(Keys.RelativeFilePath, @doc.FilePath(Keys.WritePath)),
     OrderBy(@doc.String(Keys.GroupKey))
 );
 
+// Renders individual addin pages
 Pipelines.Add("RenderAddins",
     Documents("Addins"),
     Razor()
@@ -49,6 +59,7 @@ Pipelines.Add("RenderAddins",
     WriteFiles()
 );
 
+// Renders reference page
 Pipelines.Add("RenderDsl",
     Documents("DslAliases"),
     Razor()
@@ -58,6 +69,7 @@ Pipelines.Add("RenderDsl",
     WriteFiles()
 );
 
+// Creates sitemap
 Pipelines.Add("BuildSiteMap",
     Documents(@ctx.Documents.ExceptPipeline("Addins").Except(@ctx.Documents.FromPipeline("Code"))),
     Sitemap(),

--- a/input/_AddinsLayout.cshtml
+++ b/input/_AddinsLayout.cshtml
@@ -12,6 +12,7 @@
     string repository = Model.String("Repository");
     string version = Model.String("Version");
     string categories = (String.Join(", ", Model.List<string>("Categories")));
+    var assemblies = Model.List<string>("Assemblies");
 }
 
 <section class="content-header">
@@ -41,6 +42,33 @@
                 </p>
             </div>
         </div>
+
+        @if (assemblies != null)
+        {
+            <h2 class="no-anchor">Aliases</h2>
+
+            // Read classes containing aliases from current addin.
+            var aliasClasses =
+                Documents["Aliases"]
+                    .Where(
+                        aliasDocument =>
+                            aliasDocument != null &&
+                            aliasDocument.Document(CodeAnalysisKeys.ContainingAssembly) != null &&
+                            assemblies.Any(
+                                addinAssembly =>
+                                    addinAssembly != null &&
+                                    addinAssembly.Contains(
+                                        aliasDocument.Document(CodeAnalysisKeys.ContainingAssembly).String("Name") + ".dll")));
+
+            @Html.Partial(
+                "_AliasesList",
+                aliasClasses,
+                new ViewDataDictionary(ViewData)
+                {
+                    { "groupHeadingLevel", 3 },
+                    { "showAddinReference", false }
+                })
+        }
     </article>
 
     <aside class="col-sm-4 extension-info" aria-label="Extension info" >

--- a/input/_AliasesList.cshtml
+++ b/input/_AliasesList.cshtml
@@ -1,0 +1,70 @@
+@model IEnumerable<IDocument>
+
+@{
+    int groupHeadingLevel = (int?)ViewData["groupHeadingLevel"] ?? 1;
+    bool showAddinReference = (bool?)ViewData["showAddinReference"] ?? true;
+
+    var aliasGroups =
+        Model
+            .SelectMany(x => x.DocumentList(CodeAnalysisKeys.Members))
+            .Where(x => x.String("Kind") == "Method")
+            .Select(x => new
+            {
+                Doc = x,
+                MethodAlias = x.DocumentList(CodeAnalysisKeys.Attributes).Any(attr => attr.String(CodeAnalysisKeys.Name) == "CakeMethodAliasAttribute"),
+                PropertyAlias = x.DocumentList(CodeAnalysisKeys.Attributes).Any(attr => attr.String(CodeAnalysisKeys.Name) == "CakePropertyAliasAttribute")
+            })
+            .Where(x => x.MethodAlias || x.PropertyAlias)
+            .GroupBy(x => x.Doc.DocumentList(CodeAnalysisKeys.Attributes)
+                .Where(attr => attr.String(CodeAnalysisKeys.Name) == "CakeAliasCategoryAttribute")
+                .Select(attr => attr.Get<Microsoft.CodeAnalysis.AttributeData>(CodeAnalysisKeys.AttributeData).ConstructorArguments.FirstOrDefault().Value)
+                .FirstOrDefault() as string ?? string.Empty)
+            .OrderBy(x => x.Key);
+}
+
+@if(!aliasGroups.Any())
+{
+    <p>No aliases found</p>
+}
+else {
+    @foreach(var aliasGroup in aliasGroups)
+    {
+        string groupName = string.IsNullOrEmpty(aliasGroup.Key) ? "General" : aliasGroup.Key;
+        @Html.Raw($"<h{groupHeadingLevel} id='{groupName.Replace(" ", "-")}'>{groupName}</h{groupHeadingLevel}>")
+        <div class="box">
+            <div class="box-body no-padding">
+                <table class="table table-striped table-hover two-cols">
+                    @foreach(var alias in aliasGroup.OrderBy(x => x.Doc.String(CodeAnalysisKeys.DisplayName)))
+                    {
+                        <tr>
+                            <td>
+                                @if(alias.MethodAlias)
+                                {
+                                    <text>@Context.GetTypeLink(alias.Doc, false)</text>
+                                }
+                                else
+                                {
+                                    <text>@Context.GetTypeLink(alias.Doc, alias.Doc.String("Name"), false)</text>
+                                }
+                            </td>
+                            <td>
+                                @Html.Raw(alias.Doc.String(CodeAnalysisKeys.Summary))
+                               @if(showAddinReference)
+                                {
+                                    IDocument assemblyDoc = alias.Doc.Document(CodeAnalysisKeys.ContainingAssembly);
+                                    if(assemblyDoc != null)
+                                    {
+                                        <text>
+                                            <br/>
+                                            <small><i>Addin from @Context.GetTypeLink(assemblyDoc)</i></small>
+                                        </text>
+                                    }
+                                }
+                            </td>
+                        </tr>
+                    }
+                </table>
+            </div>
+        </div>
+    }
+}

--- a/input/_DslLayout.cshtml
+++ b/input/_DslLayout.cshtml
@@ -1,14 +1,14 @@
 @{
 	Layout = "/_Master.cshtml";
-	
+
 	ViewData[Keys.Title] = "Reference - " + Model.String(Keys.GroupKey);
 }
 
-@section Infobar {	
+@section Infobar {
 	<div id="infobar-headings"></div>
 }
 
-@section Sidebar {    
+@section Sidebar {
     @Html.Partial("_DslSidebar")
 }
 
@@ -27,7 +27,7 @@
         string summary = Model
             .DocumentList(Keys.GroupDocuments)
             .Select(x => x.String(CodeAnalysisKeys.Summary))
-            .FirstOrDefault(x => !string.IsNullOrEmpty(x)); 
+            .FirstOrDefault(x => !string.IsNullOrEmpty(x));
     }
     @if(!string.IsNullOrWhiteSpace(summary))
     {
@@ -35,64 +35,7 @@
         <div>@Html.Raw(summary)</div>
     }
 
-    @{
-        var aliasGroups = Model
-            .DocumentList(Keys.GroupDocuments)
-            .SelectMany(x => x.DocumentList(CodeAnalysisKeys.Members))
-            .Where(x => x.String("Kind") == "Method")
-            .Select(x => new 
-            {
-                Doc = x,
-                MethodAlias = x.DocumentList(CodeAnalysisKeys.Attributes).Any(attr => attr.String(CodeAnalysisKeys.Name) == "CakeMethodAliasAttribute"),
-                PropertyAlias = x.DocumentList(CodeAnalysisKeys.Attributes).Any(attr => attr.String(CodeAnalysisKeys.Name) == "CakePropertyAliasAttribute")
-            })
-            .Where(x => x.MethodAlias || x.PropertyAlias)
-            .GroupBy(x => x.Doc.DocumentList(CodeAnalysisKeys.Attributes)
-                .Where(attr => attr.String(CodeAnalysisKeys.Name) == "CakeAliasCategoryAttribute")
-                .Select(attr => attr.Get<Microsoft.CodeAnalysis.AttributeData>(CodeAnalysisKeys.AttributeData).ConstructorArguments.FirstOrDefault().Value)
-                .FirstOrDefault() as string ?? string.Empty)
-            .OrderBy(x => x.Key);
-    }
+    @Html.Partial("_AliasesList", Model.DocumentList(Keys.GroupDocuments))
 
-    @foreach(var aliasGroup in aliasGroups)
-    {
-        string groupName = string.IsNullOrEmpty(aliasGroup.Key) ? "General" : aliasGroup.Key;
-        <h1 id="@(groupName.Replace(" ", "-"))">@groupName</h1>  
-        <div class="box">
-            <div class="box-body no-padding">
-                <table class="table table-striped table-hover two-cols">
-                    @foreach(var alias in aliasGroup.OrderBy(x => x.Doc.String(CodeAnalysisKeys.DisplayName)))
-                    {
-                        <tr>
-                            <td>
-                                @if(alias.MethodAlias)
-                                {
-                                    <text>@Context.GetTypeLink(alias.Doc, false)</text>
-                                }
-                                else
-                                {
-                                    <text>@Context.GetTypeLink(alias.Doc, alias.Doc.String("Name"), false)</text>
-                                }
-                            </td>
-                            <td>
-                                @Html.Raw(alias.Doc.String(CodeAnalysisKeys.Summary))
-                                @{
-                                    IDocument assemblyDoc = alias.Doc.Document(CodeAnalysisKeys.ContainingAssembly);
-                                    if(assemblyDoc != null)
-                                    {
-                                        <text>
-                                            <br/>
-                                            <small><i>Addin from @Context.GetTypeLink(assemblyDoc)</i></small>
-                                        </text>
-                                    }
-                                }
-                            </td>
-                        </tr>
-                    }
-                </table>
-            </div>
-        </div>
-    }
-    
     @RenderBody()
 </section>

--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -181,6 +181,10 @@ ul.share-buttons img{
   margin-bottom: 20px;
 }
 
+.extension-details h2 {
+  margin-top: 40px;
+}
+
 .extension-info li {
   margin-bottom: 12px;
 }


### PR DESCRIPTION
Shows a list of aliases provided by a specific addin.

![image](https://user-images.githubusercontent.com/2190718/97062289-90989e00-159a-11eb-9c64-f31f6777df27.png)

Fixes #927 