### PR TITLE
Make sure column for alias list is wrapped

### DIFF
--- a/input/_AliasesList.cshtml
+++ b/input/_AliasesList.cshtml
@@ -33,7 +33,7 @@ else {
         @Html.Raw($"<h{groupHeadingLevel} id='{groupName.Replace(" ", "-")}'>{groupName}</h{groupHeadingLevel}>")
         <div class="box">
             <div class="box-body no-padding">
-                <table class="table table-striped table-hover two-cols">
+                <table class="alias-list table table-striped table-hover two-cols">
                     @foreach(var alias in aliasGroup.OrderBy(x => x.Doc.String(CodeAnalysisKeys.DisplayName)))
                     {
                         <tr>

--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -193,3 +193,16 @@ ul.share-buttons img{
   height: 12px;
   vertical-align: unset;
 }
+
+// Alias list
+
+.alias-list td {
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word; // Non standard value for WebKit
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+}
+


### PR DESCRIPTION
Make sure column for alias list is wrapped when it contains a very long word without spaces.

Before:

![image](https://user-images.githubusercontent.com/2190718/97095571-6827a700-1661-11eb-82f9-471b64d15d92.png)

After:

![image](https://user-images.githubusercontent.com/2190718/97095577-7bd30d80-1661-11eb-905f-d08dc50aeaa7.png)
