### PR TITLE
Show label column only if there are labels set for an addin

### DIFF
--- a/input/_ExtensionsList.cshtml
+++ b/input/_ExtensionsList.cshtml
@@ -51,10 +51,13 @@
                         <i class="fa fa-github"></i>
                         <a href="@repository" target="_blank">@repository.Replace("https://github.com/", string.Empty).TrimEnd('/')</a>
                     </li>
-                    <li>
-                        <i class="fa fa-tags"></i>
-                        @categories
-                    </li>
+                    @if (!string.IsNullOrWhiteSpace(categories))
+                    {
+                        <li>
+                            <i class="fa fa-tags"></i>
+                            @categories
+                        </li>
+                    }
                 </ul>
 
                 <div class="extension-details">


### PR DESCRIPTION
Show label column only if there are labels set for an addin.

Before:

![image](https://user-images.githubusercontent.com/2190718/97113236-440fa880-16e9-11eb-8762-49f2e74137d6.png)

After:

![image](https://user-images.githubusercontent.com/2190718/97113250-5984d280-16e9-11eb-9f36-03fdb0da29ce.png)
