### PR TITLE
Remove Prerelease flag from addin metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The format of an addin file generally looks like:
 ```
 Name: Cake.Wyam
 NuGet: Cake.Wyam
-Prerelease: true
 Assemblies:
 - "/**/Cake.Wyam.dll"
 Repository: https://github.com/Wyamio/Wyam
@@ -37,8 +36,6 @@ Categories:
 - Documentation
 - Static Site Generation
 ```
-
-Note that the `Prerelease` flag can be omitted for non-prerelease packages and controls whether NuGet will attempt to download a prerelease version of the package when generating the site.
 
 ## Search
 

--- a/addins/Cake.AssemblyInfoReflector.yml
+++ b/addins/Cake.AssemblyInfoReflector.yml
@@ -5,6 +5,5 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.AssemblyInfoReflector/
 Author: wexman
 Description: Cake addin for retrieving assembly info from an existing assembly.
-Prerelease: "true"
 Categories:
 - assembly info

--- a/addins/Cake.AutoRest.yml
+++ b/addins/Cake.AutoRest.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/agc93/Cake.AutoRest/
 Author: Alistair Chapman
 Description: Cake addin for generating client code from compatible API definitions (including Swagger).
-Prerelease: "true"
 Categories:
 - azure
 - swagger

--- a/addins/Cake.AzCopy.yml
+++ b/addins/Cake.AzCopy.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/agc93/Cake.AzCopy/
 Author: Alistair Chapman
 Description: A simple Cake addin powered by the AzCopy utility for uploading and downloading files to and from Azure Storage (including Blob, Table and Files).
-Prerelease: "true"
 Categories:
 - azure
 - io

--- a/addins/Cake.Azure.yml
+++ b/addins/Cake.Azure.yml
@@ -5,6 +5,5 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.Azure/
 Author: DixonDs
 Description: Cake plugin to manage Azure resources
-Prerelease: "true"
 Categories:
 - azure

--- a/addins/Cake.Board.Asana.yml
+++ b/addins/Cake.Board.Asana.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.Board/
 Author: Nicola Biancolini
 Description: This add-in allows you to interact directly with the tasks of Asana.
-Prerelease: "true"
 Categories:
 - asana
 - task

--- a/addins/Cake.Board.AzureBoards.yml
+++ b/addins/Cake.Board.AzureBoards.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.Board/
 Author: Nicola Biancolini
 Description: This add-in allows you to interact directly with the work items of Azure Boards.
-Prerelease: "true"
 Categories:
 - azure
 - azure boards

--- a/addins/Cake.ClickTwice.yml
+++ b/addins/Cake.ClickTwice.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/agc93/clicktwice/
 Author: agc93
 Description: Cake host for ClickTwice publishing, including the addin and all required libraries
-Prerelease: "true"
 Categories:
 - clicktwice
 - publish

--- a/addins/Cake.DocCreator.yml
+++ b/addins/Cake.DocCreator.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/agc93/DocCreator/
 Author: agc93
 Description: A Cake addin to generate HTML documentation from Markdown source, using DocCreator
-Prerelease: "true"
 Categories:
 - documentation
 - markdown

--- a/addins/Cake.Graph.yml
+++ b/addins/Cake.Graph.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.Graph/
 Author: wozzo
 Description: An alias for Cake to help with displaying Task dependencies
-Prerelease: "true"
 Categories:
 - graph
 - nodes

--- a/addins/Cake.Handlebars.yml
+++ b/addins/Cake.Handlebars.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/agc93/Cake.Handlebars/
 Author: Alistair Chapman
 Description: A simple Cake addin for rendering and compiling Handlebars templates.
-Prerelease: "true"
 Categories:
 - code generation
 - documentation

--- a/addins/Cake.Helm.yml
+++ b/addins/Cake.Helm.yml
@@ -5,6 +5,5 @@ Assemblies:
 Repository: https://github.com/santey/Cake.Helm/
 Author: pitermarx
 Description: Cake AddIn that extends Cake with Helm
-Prerelease: "true"
 Categories:
 - helm

--- a/addins/Cake.ISO.yml
+++ b/addins/Cake.ISO.yml
@@ -5,6 +5,5 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.ISO/
 Author: Austin Parker
 Description: Create an ISO as part of a Cake build.
-Prerelease: "true"
 Categories:
 - misc

--- a/addins/Cake.Liquibase.yml
+++ b/addins/Cake.Liquibase.yml
@@ -5,6 +5,5 @@ Assemblies:
 Repository: https://github.com/papauorg/Cake.Liquibase/
 Author: Philipp Grathwohl
 Description: Addin for running liquibase database migrations with the Cake build system.
-Prerelease: "true"
 Categories:
 - database

--- a/addins/Cake.Microsoft.Extensions.Configuration.yml
+++ b/addins/Cake.Microsoft.Extensions.Configuration.yml
@@ -5,6 +5,5 @@ Assemblies:
 Repository: https://www.nuget.org/packages/Cake.Microsoft.Extensions.Configuration/
 Author: Jonathan Kuleff
 Description: Cake Addin for strongly typed configuration
-Prerelease: "true"
 Categories:
 - configuration

--- a/addins/Cake.MiniCover.yml
+++ b/addins/Cake.MiniCover.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/nlowe/Cake.MiniCover/
 Author: Nathan Lowe
 Description: Cake addin for MiniCover
-Prerelease: "true"
 Categories:
 - code coverage
 - testing

--- a/addins/Cake.NSwag.Console.yml
+++ b/addins/Cake.NSwag.Console.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/agc93/Cake.NSwag.Console/
 Author: agc93
 Description: A simple Cake addin powered by NSwag for compiling client code and API definitions from a variety of sources
-Prerelease: "true"
 Categories:
 - swagger
 - api

--- a/addins/Cake.NSwag.yml
+++ b/addins/Cake.NSwag.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.NSwag/
 Author: Alistair Chapman
 Description: Cake addin for compiling client code and API definitions (including Swagger) using the NSwag toolchain. If you have issues running this addin on .NET Core, try using Cake.NSwag.Console instead.
-Prerelease: "true"
 Categories:
 - swagger
 - api

--- a/addins/Cake.Newman.yml
+++ b/addins/Cake.Newman.yml
@@ -5,6 +5,5 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.Newman/
 Author: Alistair Chapman
 Description: Cake addin for testing Postman Collection APIs using the Newman CLI.
-Prerelease: "true"
 Categories:
 - postman

--- a/addins/Cake.SimpleVersion.yml
+++ b/addins/Cake.SimpleVersion.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/Kieranties/SimpleVersion/
 Author: Kieranties
 Description: SimpleVersion - A simple tool to version your code
-Prerelease: "true"
 Categories:
 - semver
 - versioning

--- a/addins/Cake.Vagrant.yml
+++ b/addins/Cake.Vagrant.yml
@@ -5,6 +5,5 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.Vagrant/
 Author: Alistair Chapman
 Description: Cake addin for creating and managing Vagrant virtual machines
-Prerelease: "true"
 Categories:
 - vagrant

--- a/addins/Cake.Vault.yml
+++ b/addins/Cake.Vault.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/cake-contrib/Cake.Vault/
 Author: jincod
 Description: Get vault secrets.
-Prerelease: "true"
 Categories:
 - configs generator
 - vault

--- a/addins/Cake.XmlConfigStructureBuilder.yml
+++ b/addins/Cake.XmlConfigStructureBuilder.yml
@@ -5,7 +5,6 @@ Assemblies:
 Repository: https://github.com/graph-uk/Cake.XmlConfigStructureBuilder/
 Author: BggClr
 Description: The project compiles multiple xml configs to single one using the CTT.
-Prerelease: "true"
 Categories:
 - configs generator
 - deployment

--- a/build.cake
+++ b/build.cake
@@ -39,7 +39,6 @@ class AddinSpec
 {
     public string Name { get; set; }
     public string NuGet { get; set; }
-    public bool Prerelease { get; set; }
     public List<string> Assemblies { get; set; }
     public string Repository { get; set; }
     public string Author { get; set; }


### PR DESCRIPTION
Remove Prerelease flag from addin metadata since it currently is not used. If we want to support it in the future again we should design implementation from scratch. Currently it just creates unecessary noise with PRs created by addin discoverer.