### PR TITLE
Improve documentation for calling aliases

### DIFF
--- a/input/docs/fundamentals/aliases.md
+++ b/input/docs/fundamentals/aliases.md
@@ -9,6 +9,17 @@ Cake supports something called script aliases. Script aliases are convenience me
 See [Reference](/dsl) for a list of available aliases.
 :::
 
+# Calling aliases
+
+Aliases are extension methods of `ICakeContext`.
+
+## Calling aliases in a Cake script
+
+When using a Cake script with [.NET Core Tool](/docs/running-builds/runners/dotnet-core-tool),
+[Cake runner for .NET Framework](/docs/running-builds/runners/cake-runner-for-dotnet-framework) or
+[Cake runner for .NET Core](/docs/running-builds/runners/cake-runner-for-dotnet-core)
+aliases can be called directly inside a task, without explicitly passing the context:
+
 ```csharp
 Task("Clean")
     .Does(() =>
@@ -19,6 +30,26 @@ Task("Clean")
     // Clean a directory.
     CleanDirectory("./temp");
 });
+```
+
+## Calling aliases in Frosting
+
+Inside a [Cake Frosting](/docs/running-builds/runners/cake-frosting) project aliases can be
+called as extension methods of the context passed to the `Run` method of the task:
+
+```csharp
+public sealed class Clean : FrostingTask<Context>
+{
+    public override void Run(Context context)
+    {
+        // Delete a file.
+        context.DeleteFile("./file.txt");
+
+        // Clean a directory.
+        context.CleanDirectory("./temp");
+    }
+}
+
 ```
 
 # Custom aliases


### PR DESCRIPTION
Adds documentation for Frosting tasks and mentions that in Cake script tasks aliases can be called directly.