### PR TITLE
Render categories as badges on extension detail page

### DIFF
--- a/input/_AddinsLayout.cshtml
+++ b/input/_AddinsLayout.cshtml
@@ -11,7 +11,7 @@
     string author = Model.String("Author");
     string repository = Model.String("Repository");
     string version = Model.String("Version");
-    string categories = (String.Join(", ", Model.List<string>("Categories")));
+    string categories = (String.Join(" ", Model.List<string>("Categories").Select(x => $"<span class=\"badge badge-secondary\">{x}</span>")));
     var assemblies = Model.List<string>("Assemblies");
 }
 
@@ -94,7 +94,7 @@
 
         <h2 class="no-anchor">Categories</h2>
         <p>
-            @categories
+            @Html.Raw(categories)
         </p>
     </aside>
 </section>


### PR DESCRIPTION
Render categories as badges on extension detail page

![image](https://user-images.githubusercontent.com/2190718/97239224-625dcd00-17eb-11eb-87f9-95e3fb8b4ef3.png)
