### PR TITLE
Fix link for vscode intellisense on runners page

### DIFF
--- a/input/docs/running-builds/runners/index.md
+++ b/input/docs/running-builds/runners/index.md
@@ -25,4 +25,4 @@ There are different runners available for running Cake scripts.
 [Cake Frosting]: cake-frosting
 [Cake runner for .NET Framework]: cake-runner-for-dotnet-framework
 [Cake runner for .NET Core]: cake-runner-for-dotnet-core
-[IntelliSense in Visual Studio Code]: ../integrations/editors/vscode/intellisense
+[IntelliSense in Visual Studio Code]: ../../integrations/editors/vscode/intellisense


### PR DESCRIPTION
Fixes relative link that broke after runners documentation was moved to the "Running Builds" section in 804f8f8f7e5e40773be09084ffb751d39813d7ef