### PR TITLE
Remove global namespace from API documentation

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -6,6 +6,7 @@ Settings[DocsKeys.Title] = "Cake";
 Settings[DocsKeys.Logo] = "/assets/img/logo.png";
 Settings[DocsKeys.SourceFiles] = "../release/repo/src/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs";
 Settings[DocsKeys.BaseEditUrl] = "https://github.com/cake-build/website/blob/master/input/";
+Settings[DocsKeys.IncludeGlobalNamespace] = false;
 Settings[DocsKeys.IncludeDateInPostPath] = true;
 Settings[DocsKeys.BlogAtomPath] = "blog/feed/atom/index.xml";
 Settings[DocsKeys.BlogRssPath] = "blog/feed/rss/index.xml";


### PR DESCRIPTION
Remove global namespace from API documentation (https://cakebuild.net/api/global/)