### PR TITLE
Mention community on start page

### DIFF
--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -9,7 +9,7 @@ NoGutter: true
             <div class="col-xs-12 col-sm-6">
                 <h1>What is Cake?</h1>
                 <p>
-                    Cake (C# Make) is a cross-platform build automation system with a C# DSL for tasks such as compiling code, copying files and folders, running unit tests, compressing files and building NuGet packages.
+                    Cake (C# Make) is a free and open source cross-platform build automation system with a C# DSL for tasks such as compiling code, copying files and folders, running unit tests, compressing files and building NuGet packages.
                 </p>
                 <p>
                     <a class="btn btn-primary btn-lg" href="/docs/getting-started/setting-up-a-new-project" role="button">Get Started &raquo;</a>
@@ -62,11 +62,11 @@ NoGutter: true
             </p>
         </div>
         <div class="col-sm-4">
-            <h3 class="no-anchor">Open source</h3>
+            <h3 class="no-anchor">Community</h3>
             <p>
-                We believe in open source and so should you. The source code for Cake is
-                <a href="https://github.com/cake-build">hosted on GitHub</a> and
-                includes everything needed to build it yourself.
+                There's an amazing community around Cake with <a href="/community/thanks">several hundred contributors</a> which are helping out with documentation,
+                adding new features, raising issues, fixing bugs and fill missing gaps with <a href="/extensions">extensions</a>.
+                See <a href="community">Community</a> how to get involved.
             </p>
         </div>
     </div>


### PR DESCRIPTION
Community is one of Cakes strongest arguments. This PR mentions it on the start page and replaces the open-source box, which is now mentioned in the heading instead.

![image](https://user-images.githubusercontent.com/2190718/97843613-e3382f80-1ce9-11eb-83ad-a6feb02c8847.png)
