### PR TITLE
Rename .NET Core Tool to .NET Tool

### DIFF
--- a/input/docs/fundamentals/aliases.md
+++ b/input/docs/fundamentals/aliases.md
@@ -15,7 +15,7 @@ Aliases are extension methods of `ICakeContext`.
 
 ## Calling aliases in a Cake script
 
-When using a Cake script with [.NET Core Tool](/docs/running-builds/runners/dotnet-core-tool),
+When using a Cake script with [.NET Tool](/docs/running-builds/runners/dotnet-tool),
 [Cake runner for .NET Framework](/docs/running-builds/runners/cake-runner-for-dotnet-framework) or
 [Cake runner for .NET Core](/docs/running-builds/runners/cake-runner-for-dotnet-core)
 aliases can be called directly inside a task, without explicitly passing the context:

--- a/input/docs/getting-started/setting-up-a-new-project.md
+++ b/input/docs/getting-started/setting-up-a-new-project.md
@@ -12,7 +12,7 @@ This is a guide to get started with Cake and to show you how Cake works.
 Choose the runner suitable for your scenario.
 See [Runners](../running-builds/runners) for other possibilities how to run Cake scripts.
 
-For this tutorial we use the recommended approach using the [.NET Core Tool](../running-builds/runners/dotnet-core-tool)
+For this tutorial we use the recommended approach using the [.NET Tool](../running-builds/runners/dotnet-tool)
 on .NET Core 3.0 and newer.
 
 Make sure to have a tool manifest available in your repository or create one using the following command:
@@ -28,7 +28,7 @@ dotnet tool install Cake.Tool --version x.y.z
 ```
 
 :::{.alert .alert-info}
-See [Bootstrapping .NET Core Tool](../running-builds/runners/dotnet-core-tool#bootstrapping-for.net-core-tool) for details about the bootstrapping process.
+See [Bootstrapping .NET Tool](../running-builds/runners/dotnet-tool#bootstrapping-for.net-tool) for details about the bootstrapping process.
 :::
 
 # Create initial build script

--- a/input/docs/integrations/editors/atom.md
+++ b/input/docs/integrations/editors/atom.md
@@ -6,7 +6,7 @@ RedirectFrom: docs/editors/atom
 # Syntax Highlighting
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool1">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool1">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting1">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx1">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core1">Cake runner for .NET Core</a></li>
@@ -39,7 +39,7 @@ RedirectFrom: docs/editors/atom
 # IntelliSense
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool2">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool2">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting2">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx2">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core2">Cake runner for .NET Core</a></li>

--- a/input/docs/integrations/editors/visualstudio.md
+++ b/input/docs/integrations/editors/visualstudio.md
@@ -7,7 +7,7 @@ RedirectFrom: docs/editors/visualstudio
 # Syntax Highlighting
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool1">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool1">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting1">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx1">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core1">Cake runner for .NET Core</a></li>
@@ -39,7 +39,7 @@ RedirectFrom: docs/editors/visualstudio
 # IntelliSense
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool2">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool2">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting2">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx2">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core2">Cake runner for .NET Core</a></li>
@@ -81,7 +81,7 @@ You can also use the commands from the Build > Cake Build menu to install the de
 # Code Snippets
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool3">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool3">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting3">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx3">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core3">Cake runner for .NET Core</a></li>
@@ -113,7 +113,7 @@ You can also use the commands from the Build > Cake Build menu to install the de
 # Task Runner
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool4">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool4">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting4">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx4">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core4">Cake runner for .NET Core</a></li>
@@ -121,7 +121,7 @@ You can also use the commands from the Build > Cake Build menu to install the de
 
 <div class="tab-content">
     <div id="tool4" class="tab-pane fade in active">
-            Task runner is currently not supported for <a href="/docs/running-builds/runners/dotnet-core-tool">.NET Core Tool</a>.
+            Task runner is currently not supported for <a href="/docs/running-builds/runners/dotnet-tool">.NET Tool</a>.
     </div>
     <div id="frosting4" class="tab-pane fade">
         <p>

--- a/input/docs/integrations/editors/vscode/intellisense.md
+++ b/input/docs/integrations/editors/vscode/intellisense.md
@@ -9,7 +9,7 @@ RedirectFrom: docs/editors/vscode/intellisense
 To enable IntelliSense support in Visual Studio Code follow these steps:
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core">Cake runner for .NET Core</a></li>

--- a/input/docs/integrations/editors/vscode/snippets.md
+++ b/input/docs/integrations/editors/vscode/snippets.md
@@ -5,7 +5,7 @@ RedirectFrom: docs/editors/vscode/snippets
 ---
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core">Cake runner for .NET Core</a></li>

--- a/input/docs/running-builds/configuration/set-configuration-values.md
+++ b/input/docs/running-builds/configuration/set-configuration-values.md
@@ -47,7 +47,7 @@ The configuration file should be located in the same directory as your Cake scri
 Finally, you can specify an input parameter directly to Cake, in the following format:
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool1">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool1">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting1">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx1">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core1">Cake runner for .NET Core</a></li>
@@ -89,7 +89,7 @@ Passing a configuration value directly to Cake will override the same configurat
 When configuring NuGet sources in both `cake.config`, and via the command line, multiple sources can be supplied by joining them with a semicolon:
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool1">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool1">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting1">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx1">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core1">Cake runner for .NET Core</a></li>

--- a/input/docs/running-builds/runners/cake-runner-for-dotnet-core.md
+++ b/input/docs/running-builds/runners/cake-runner-for-dotnet-core.md
@@ -3,7 +3,7 @@ Title: Cake runner for .NET Core
 ---
 
 :::{.alert .alert-warning}
-The Cake runner for .NET Core is deprecated and it is suggested to use [.NET Core Tool](dotnet-core-tool) for running Cake under .NET Core.
+The Cake runner for .NET Core is deprecated and it is suggested to use [.NET Tool](dotnet-tool) for running Cake under .NET Core.
 :::
 
 # Requirements

--- a/input/docs/running-builds/runners/cake-runner-for-dotnet-framework.md
+++ b/input/docs/running-builds/runners/cake-runner-for-dotnet-framework.md
@@ -3,7 +3,7 @@ Title: Cake runner for .NET Framework
 ---
 
 This runner is mainly for backwards compatibility where scripts or addins are used which require .NET Framework.
-In all other cases it is recommended to use [.NET Core Tool](dotnet-core-tool).
+In all other cases it is recommended to use [.NET Tool](dotnet-tool).
 
 # Requirements
 

--- a/input/docs/running-builds/runners/dotnet-tool.md
+++ b/input/docs/running-builds/runners/dotnet-tool.md
@@ -1,5 +1,6 @@
 Order: 10
-Title: .NET Core Tool
+Title: .NET Tool
+RedirectFrom: docs/running-builds/runners/dotnet-core-tool
 ---
 
 :::{.alert .alert-success}
@@ -18,7 +19,7 @@ dotnet cake [script] [switches]
 
 ^"../../../Shared/switches.txt"
 
-# Bootstrapping for .NET Core Tool
+# Bootstrapping for .NET Tool
 
 :::{.alert .alert-info}
 The following instructions require .NET Core 3.0 or newer.
@@ -27,10 +28,10 @@ See [How to manage .NET Core tools](https://docs.microsoft.com/en-us/dotnet/core
 
 ## Setup
 
-There's a one-time setup required for configuring a repository to use Cake .NET Core tool.
+There's a one-time setup required for configuring a repository to use Cake .NET tool.
 
 :::{.alert .alert-info}
-If you have .NET Core Tool already available in your environment you can skip the steps in this chapter.
+If you have .NET Tool already available in your environment you can skip the steps in this chapter.
 :::
 
 Make sure to have a tool manifest available in your repository or create one using the following command:

--- a/input/docs/running-builds/runners/index.md
+++ b/input/docs/running-builds/runners/index.md
@@ -13,7 +13,7 @@ There are different runners available for running Cake scripts.
 
 | Runner | Minimum required .NET version  | Supported | IntelliSense |
 |-|-|-|
-| [.NET Core Tool] | .NET Core 2.1 | <span class="glyphicon glyphicon-ok" style="color:green"></span> | <span class="glyphicon glyphicon-ok" style="color:orange"></span> [[1]](#1) |
+| [.NET Tool] | .NET Core 2.1 | <span class="glyphicon glyphicon-ok" style="color:green"></span> | <span class="glyphicon glyphicon-ok" style="color:orange"></span> [[1]](#1) |
 | [Cake Frosting] | .NET Framework 4.6.1 or .NET Core 3.1 | <span class="glyphicon glyphicon-ok" style="color:green"></span> | <span class="glyphicon glyphicon-ok" style="color:green"></span> |
 | [Cake runner for .NET Framework] | .NET Framework 4.6.1 or Mono 5.0.12 | <span class="glyphicon glyphicon-ok" style="color:green"></span> | <span class="glyphicon glyphicon-ok" style="color:orange"></span> [[1]](#1) |
 | [Cake runner for .NET Core] | .NET Core 2.0 | <span class="glyphicon glyphicon-remove" style="color:red"></span> | <span class="glyphicon glyphicon-ok" style="color:orange"></span> [[1]](#1) |
@@ -21,7 +21,7 @@ There are different runners available for running Cake scripts.
 <a id="1"></a>
 [1]: Limited support in Visual Studio Code. See [IntelliSense in Visual Studio Code]
 
-[.NET Core Tool]: dotnet-core-tool
+[.NET Tool]: dotnet-tool
 [Cake Frosting]: cake-frosting
 [Cake runner for .NET Framework]: cake-runner-for-dotnet-framework
 [Cake runner for .NET Core]: cake-runner-for-dotnet-core

--- a/input/docs/writing-builds/args-and-environment-vars.md
+++ b/input/docs/writing-builds/args-and-environment-vars.md
@@ -21,7 +21,7 @@ Argument<bool>("showstuff", false);
 Execution:
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool2">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool2">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting2">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx2">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core2">Cake runner for .NET Core</a></li>

--- a/input/docs/writing-builds/reproducible-builds/pinning-cake-version.md
+++ b/input/docs/writing-builds/reproducible-builds/pinning-cake-version.md
@@ -5,7 +5,7 @@ Description: How to make Cake builds reproducible
 To have deterministic builds it is important that on every build the same version of Cake is used.
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool1">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool1">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting1">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx1">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core1">Cake runner for .NET Core</a></li>

--- a/input/docs/writing-builds/running-targets.md
+++ b/input/docs/writing-builds/running-targets.md
@@ -39,7 +39,7 @@ RunTarget(target);
 With this Cake script, you can run a specific target by passing the `--target` argument to Cake. Thus, we can run the `"Publish"` target by calling:
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool1">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool1">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting1">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx1">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core1">Cake runner for .NET Core</a></li>
@@ -101,7 +101,7 @@ The `--exclusive` parameter causes `RunTarget` to run only the specified target 
 This command runs the `Publish` target without running the `Build` target:
 
 <ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool2">.NET Core Tool</a></li>
+    <li class="active"><a data-toggle="tab" href="#tool2">.NET Tool</a></li>
     <li><a data-toggle="tab" href="#frosting2">Cake Frosting</a></li>
     <li><a data-toggle="tab" href="#netfx2">Cake runner for .NET Framework</a></li>
     <li><a data-toggle="tab" href="#core2">Cake runner for .NET Core</a></li>


### PR DESCRIPTION
Rename .NET Core Tool to .NET Tool in preparation of .NET 5 release (e.g. nuget.org already uses this release, at least partially 😉)