### PR TITLE
Mention Frosting on start page

### DIFF
--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -29,7 +29,8 @@ NoGutter: true
         <div class="col-sm-4">
             <h3 class="no-anchor">Familiar</h3>
             <p>
-                Cake is built on top of the Roslyn compiler which enables you to write your build scripts in pure C#.
+                Cake is built on top of the Roslyn compiler which enables you to write your build scripts in pure C# in
+                either a standard console project, using <a href="docs/running-builds/runners/cake-frosting">Cake Frosting</a>, or as Cake script.
             </p>
         </div>
         <div class="col-sm-4">


### PR DESCRIPTION
Make it clear on start page that console applications are a first class citizen with Cake and linking to Frosting. 