### PR TITLE
Add documentation for every build server Cake provides a build system integration

### DIFF
--- a/input/_ExtensionsList.cshtml
+++ b/input/_ExtensionsList.cshtml
@@ -1,38 +1,19 @@
 @model IEnumerable<IDocument>
 
 @{
-    var extensionType = new List<string> { "Addin" };
-
     var extensions =
         Model
-            .Where(x =>
-                x.String("Type") != null && 
-                extensionType.Any(y => y.Equals(x.String("Type"), StringComparison.OrdinalIgnoreCase)))
             .OrderBy(x => x.String("Name"))
             .ToList();
 }
 
-<div class="alert alert-info">
-    <p>
-        This page contains extensions for Cake.
-        If you want to file an issue for any extension listed here, contact the author of the extension.
-    </p>
-    <p>
-        If you're an extension author and want your extension listed here, follow the instructions <a href="https://github.com/cake-build/website/blob/master/README.md#extensions" target="_blank">here</a>.
-    </p>
-</div>
-
-<section id="extensions">
-
-    <input id="search" type="text" class="search" aria-label="Enter extensions to search" placeholder="Search for extensions..." autocomplete="off" value>
-
-    <div class="row no-margin">
-        <div id="result-count" class="col-md-10 no-padding">
-            @extensions.Count() extensions found
-        </div>
-    </div>
-
-    <div class="list-extensions list" role="list">
+<div class="list-extensions list" role="list">
+    @if (!extensions.Any())
+    {
+        <p>
+            No extensions found
+        </p>
+    }
 
     @foreach(IDocument extension in extensions)
     {
@@ -78,21 +59,4 @@
             </div>
         </article>
     }
-    </div>
-</section>
-
-<script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-<script>
-    var options = {
-      valueNames: [
-        { data: ['name'] },
-        { data: ['categories'] }
-      ]
-    };
-
-    var extensionList = new List('extensions', options);
-
-    extensionList.on('searchComplete', function() {
-        document.getElementById("result-count").innerHTML = extensionList.update().matchingItems.length + " extensions found";
-    });
-</script>
+</div>

--- a/input/_ExtensionsPage.cshtml
+++ b/input/_ExtensionsPage.cshtml
@@ -1,0 +1,52 @@
+@model IEnumerable<IDocument>
+
+@{
+    var extensionType = new List<string> { "Addin" };
+
+    var extensions =
+        Model
+            .Where(x =>
+                x.String("Type") != null && 
+                extensionType.Any(y => y.Equals(x.String("Type"), StringComparison.OrdinalIgnoreCase)))
+            .OrderBy(x => x.String("Name"))
+            .ToList();
+}
+
+<div class="alert alert-info">
+    <p>
+        This page contains extensions for Cake.
+        If you want to file an issue for any extension listed here, contact the author of the extension.
+    </p>
+    <p>
+        If you're an extension author and want your extension listed here, follow the instructions <a href="https://github.com/cake-build/website/blob/master/README.md#extensions" target="_blank">here</a>.
+    </p>
+</div>
+
+<section id="extensions">
+
+    <input id="search" type="text" class="search" aria-label="Enter extensions to search" placeholder="Search for extensions..." autocomplete="off" value>
+
+    <div class="row no-margin">
+        <div id="result-count" class="col-md-10 no-padding">
+            @extensions.Count() extensions found
+        </div>
+    </div>
+    
+    @Html.Partial("_ExtensionsList", extensions)
+</section>
+
+<script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
+<script>
+    var options = {
+      valueNames: [
+        { data: ['name'] },
+        { data: ['categories'] }
+      ]
+    };
+
+    var extensionList = new List('extensions', options);
+
+    extensionList.on('searchComplete', function() {
+        document.getElementById("result-count").innerHTML = extensionList.update().matchingItems.length + " extensions found";
+    });
+</script>

--- a/input/docs/integrations/build-systems/appveyor/index.cshtml
+++ b/input/docs/integrations/build-systems/appveyor/index.cshtml
@@ -1,0 +1,45 @@
+Order: 10
+Title: AppVeyor
+Description: Integration with AppVeyor
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/24BFB813">AppVeyor alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.AppVeyor/IAppVeyorProvider">IAppVeyorProvider</a> instance can be used to interact with the AppVeyor environment.
+</p>
+<p>
+    The following example writes an error message if running on AppVeyor:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.AppVeyor.IsRunningOnAppVeyor)
+{
+    BuildSystem.AppVeyor.AddMessage(
+            "This is a error message.",
+            AppVeyorMessageCategoryType.Error,
+            "Error details."
+        );
+}
+else
+{
+    Information("Not running on AppVeyor");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.AppVeyor/IAppVeyorProvider">IAppVeyorProvider</a> for details and available methods to interact with AppVeyor.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "appveyor" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/azure-pipelines/azure-devops-build-task-extension.md
+++ b/input/docs/integrations/build-systems/azure-pipelines/azure-devops-build-task-extension.md
@@ -1,9 +1,10 @@
 Order: 10
-Title: Azure DevOps
-Description: Extensions and supported features for Azure DevOps
+Title: Azure DevOps Build Task Extension
+Description: Extensions for Azure DevOps which provides a Cake build task
 RedirectFrom:
   - docs/build-systems/vso
   - docs/build-systems/azure-devops
+  - docs/integrations/build-systems/azure-devops
 ---
 
 The Cake Azure DevOps build task makes it easy to run a Cake script directly, without having to invoke PowerShell or other command line scripts. This makes it easy even for team members that are not familiar with Cake to add or adjust parameters passed to your build scripts.

--- a/input/docs/integrations/build-systems/azure-pipelines/index.cshtml
+++ b/input/docs/integrations/build-systems/azure-pipelines/index.cshtml
@@ -1,0 +1,41 @@
+Order: 20
+Description: Integration with Azure Pipelines
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/AD2EF4E3">AzurePipelines alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.AzurePipelines/IAzurePipelinesProvider">IAzurePipelinesProvider</a> instance can be used to interact with the Azure Pipelines environment.
+</p>
+<p>
+    The following example writes an error message if running on Azure Pipelines:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.AzurePipelines.IsRunningOnAzurePipelines)
+{
+    BuildSystem.AzurePipelines.Commands.WriteError(
+            "This is a error message.");
+}
+else
+{
+    Information("Not running on Azure Pipelines");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.AzurePipelines/IAzurePipelinesProvider">IAzurePipelinesProvider</a> for details and available methods to interact with Azure Pipelines.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "azurepipelines", "azuredevops", "tfs" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/bamboo/index.cshtml
+++ b/input/docs/integrations/build-systems/bamboo/index.cshtml
@@ -1,0 +1,40 @@
+Order: 30
+Description: Integration with Atlassian Bamboo
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/54316A70">Bamboo alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.Bamboo/IBambooProvider/">IBambooProvider</a> instance can be used to interact with the Atlassian Bamboo environment.
+</p>
+<p>
+    The following example prints the build number if running on Atlassian Bamboo:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.Bamboo.IsRunningOnBamboo)
+{
+    Information(BuildSystem.Bamboo.Environment.Build.Number);
+}
+else
+{
+    Information("Not running on Atlassian Bamboo");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.Bamboo/IBambooProvider/">IBambooProvider</a> for details and available methods to interact with Atlassian Bamboo.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "bamboo" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/bitbucket-pipelines/index.cshtml
+++ b/input/docs/integrations/build-systems/bitbucket-pipelines/index.cshtml
@@ -1,0 +1,40 @@
+Order: 40
+Description: Integration with Atlassian Bitbucket Pipelines
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/5B57E9B0">BitbucketPipelines alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.BitbucketPipelines/IBitbucketPipelinesProvider/">IBitbucketPipelinesProvider</a> instance can be used to interact with the Atlassian Bitbucket Pipelines environment.
+</p>
+<p>
+    The following example writes pull request ID if running on Atlassian Bitbucket Pipelines:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.BitbucketPipelines.IsRunningOnBitbucketPipelines)
+{
+    Information(BuildSystem.BitbucketPipelines.Environment.PullRequest.Id);
+}
+else
+{
+    Information("Not running on Atlassian Bitbucket Pipelines");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.BitbucketPipelines/IBitbucketPipelinesProvider/">IBitbucketPipelinesProvider</a> for details and available methods to interact with Atlassian Bitbucket Pipelines.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "bitbucket" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/bitrise/index.cshtml
+++ b/input/docs/integrations/build-systems/bitrise/index.cshtml
@@ -1,0 +1,40 @@
+Order: 50
+Description: Integration with Bitrise
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/AAE697A4">Bitrise alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.Bitrise/IBitriseProvider/">IBitriseProvider</a> instance can be used to interact with the Bitrise environment.
+</p>
+<p>
+    The following example prints the build number if running on Bitrise:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.Bitrise.IsRunningOnBitrise)
+{
+    Information(BuildSystem.Bitrise.Environment.Build.BuildNumber);
+}
+else
+{
+    Information("Not running on Bitrise");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.Bitrise/IBitriseProvider/">IBitriseProvider</a> for details and available methods to interact with Bitrise.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "bitrise" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/continua-ci/index.cshtml
+++ b/input/docs/integrations/build-systems/continua-ci/index.cshtml
@@ -1,0 +1,44 @@
+Order: 60
+Title: Continua CI
+Description: Integration with Continua CI
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/BA7AF6E4">ContinuaCI alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.ContinuaCI/IContinuaCIProvider">IContinuaCIProvider</a> instance can be used to interact with the Continua CI environment.
+</p>
+<p>
+    The following example writes an error message if running on Continua CI:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.ContinuaCI.IsRunningOnContinuaCI)
+{
+    BuildSystem.ContinuaCI.WriteMessage(
+            "This is a error message.",
+            ContinuaCIMessageType.Error
+        );
+}
+else
+{
+    Information("Not running on Continua CI");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.ContinuaCI/IContinuaCIProvider">IContinuaCIProvider</a> for details and available methods to interact with Continua CI.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "continua" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/github-actions/index.cshtml
+++ b/input/docs/integrations/build-systems/github-actions/index.cshtml
@@ -1,0 +1,41 @@
+Order: 70
+Title: GitHub Actions
+Description: Integration with GitHub Actions
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/6C2FCAF0">GitHubActions alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.GitHubActions/IGitHubActionsProvider">IGitHubActionsProvider</a> instance can be used to interact with the GitHub Actions environment.
+</p>
+<p>
+    The following example prints if the build is for a pull request running on GitHub Actions:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.GitHubActions.IsRunningOnGitHubActions)
+{
+    Information(BuildSystem.GitHubActions.Environment.PullRequest.IsPullRequest);
+}
+else
+{
+    Information("Not running on GitHub Actions");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.GitHubActions/IGitHubActionsProvider">IGitHubActionsProvider</a> for details and available methods to interact with GitHub Actions.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "githubactions" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/gitlab-ci/index.cshtml
+++ b/input/docs/integrations/build-systems/gitlab-ci/index.cshtml
@@ -1,0 +1,41 @@
+Order: 80
+Title: GitLab CI/CD
+Description: Integration with GitLab CI/CD
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/701ECBFA">GitLabCI alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.GitLabCI/IGitLabCIProvider">IGitLabCIProvider</a> instance can be used to interact with the GitLab CI/CD environment.
+</p>
+<p>
+    The following example prints the build number if running on GitLab CI/CD:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.GitLabCI.IsRunningOnGitLabCI)
+{
+    Information(BuildSystem.GitLabCI.Environment.Build.Id);
+}
+else
+{
+    Information("Not running on GitLab CI/CD");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.GitLabCI/IGitLabCIProvider">IGitLabCIProvider</a> for details and available methods to interact with GitLab CI/CD.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "gitlab" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/go-cd/index.cshtml
+++ b/input/docs/integrations/build-systems/go-cd/index.cshtml
@@ -1,0 +1,41 @@
+Order: 90
+Title: GoCD
+Description: Integration with GoCD
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/315AF6B4">GoCD alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.GoCD/IGoCDProvider">IGoCDProvider</a> instance can be used to interact with the GoCD environment.
+</p>
+<p>
+    The following example prints how many times the pipeline has been run if running on GoCD:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.GoCD.IsRunningOnGoCD)
+{
+    Information(BuildSystem.GoCD.Environment.Pipeline.Counter);
+}
+else
+{
+    Information("Not running on GoCD");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.GoCD/IGoCDProvider">IGoCDProvider</a> for details and available methods to interact with GoCD.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "gocd" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/index.cshtml
+++ b/input/docs/integrations/build-systems/index.cshtml
@@ -2,4 +2,12 @@ Order: 90
 Description: Integration with build servers
 ---
 
+<p>
+    Cake can run on any build system.
+    For the most common build systems Cake provides helpers out of the box to integrate with the build system.
+</p>
+<p>
+    Additionally for some build systems specific runners or additional extensions are available.
+</p>
+
 @Html.Partial("_ChildPages")

--- a/input/docs/integrations/build-systems/jenkins/index.cshtml
+++ b/input/docs/integrations/build-systems/jenkins/index.cshtml
@@ -1,0 +1,40 @@
+Order: 100
+Description: Integration with Jenkins
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/8C013DE2">Jenkins alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.Jenkins/IJenkinsProvider">IJenkinsProvider</a> instance can be used to interact with the Jenkins environment.
+</p>
+<p>
+    The following example prints the build number if running on Jenkins:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.Jenkins.IsRunningOnJenkins)
+{
+    Information(BuildSystem.Jenkins.Environment.Build.BuildNumber);
+}
+else
+{
+    Information("Not running on Jenkins");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.Jenkins/IJenkinsProvider">IJenkinsProvider</a> for details and available methods to interact with Jenkins.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "jenkins" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/myget/index.cshtml
+++ b/input/docs/integrations/build-systems/myget/index.cshtml
@@ -1,0 +1,45 @@
+Order: 110
+Title: MyGet
+Description: Integration with MyGet build services
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/EE6E221A">MyGet alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.MyGet/IMyGetProvider">IMyGetProvider</a> instance can be used to interact with the MyGet environment.
+</p>
+<p>
+    The following example writes an error message if running on MyGet:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.MyGet.IsRunningOnMyGet)
+{
+    BuildSystem.MyGet.WriteStatus(
+            "This is a error message.",
+            MyGetBuildStatus.Error,
+            "Error details."
+        );
+}
+else
+{
+    Information("Not running on MyGet");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.MyGet/IMyGetProvider">IMyGetProvider</a> for details and available methods to interact with MyGet.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "myget" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/teamcity/index.cshtml
+++ b/input/docs/integrations/build-systems/teamcity/index.cshtml
@@ -1,0 +1,45 @@
+Order: 120
+Title: TeamCity
+Description: Integration with TeamCity
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/21507A3B">TeamCity alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.TeamCity/ITeamCityProvider/">ITeamCityProvider</a> instance can be used to interact with the TeamCity environment.
+</p>
+<p>
+    The following example writes an error message if running on TeamCity:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.TeamCity.IsRunningOnTeamCity)
+{
+    BuildSystem.TeamCity.WriteStatus(
+            "This is a error message.",
+            "error",
+            "Error details."
+        );
+}
+else
+{
+    Information("Not running on TeamCity");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.TeamCity/ITeamCityProvider/">ITeamCityProvider</a> for details and available methods to interact with TeamCity.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "teamcity" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/integrations/build-systems/travis-ci/index.cshtml
+++ b/input/docs/integrations/build-systems/travis-ci/index.cshtml
@@ -1,0 +1,41 @@
+Order: 130
+Title: Travis CI
+Description: Integration with Travis CI
+---
+
+<h1 id="included-support">Out of the box support</h1>
+
+<p>
+    The <a href="/api/Cake.Common.Build/BuildSystemAliases/BF67471C">TravisCI alias</a>, which returns an
+    <a href="/api/Cake.Common.Build.TravisCI/ITravisCIProvider">ITravisCIProvider</a> instance can be used to interact with the Travis CI environment.
+</p>
+<p>
+    The following example prints the build number if running on Travis CI:
+</p>
+
+<pre><code class="language-csharp hljs">if (BuildSystem.TravisCI.IsRunningOnTravisCI)
+{
+    Information(BuildSystem.TravisCI.Environment.Build.BuildId);
+}
+else
+{
+    Information("Not running on Travis CI");
+}</code></pre>
+
+<div class="alert alert-info">
+    <p>
+        See <a href="/api/Cake.Common.Build.TravisCI/ITravisCIProvider">ITravisCIProvider</a> for details and available methods to interact with Travis CI.
+    </p>
+</div>
+
+<h1 id="included-support">Available 3rd party extensions</h1>
+
+@{
+    var keywords = new List<string> { "travis" };
+    var extensions =
+        Documents["Extensions"]
+            .Where(x =>
+                keywords.Any(y => x.String("Name").ToLowerInvariant().Contains(y)));
+}
+
+@Html.Partial("_ExtensionsList", extensions)

--- a/input/docs/running-builds/runners/index.md
+++ b/input/docs/running-builds/runners/index.md
@@ -59,7 +59,8 @@ The following table shows build systems for which Cake provides specific integra
 
 :::{.alert .alert-info}
 Cake can run on any build system, even if not included in this list.
-For the listed build systems Cake provides 
+For the listed build systems Cake provides out of the box integrations.
+See [Build Systems](/docs/integrations/build-systems/) for details.
 :::
 
 | Runner                           | AppVeyor | Azure Pipelines | Bamboo | Bitbucket Pipelines | Bitrise | Continua CI | GitHub Actions | GitLab CI | GoCD | Jenkins | MyGet | TeamCity | TravisCI |

--- a/input/extensions/index.cshtml
+++ b/input/extensions/index.cshtml
@@ -2,4 +2,4 @@ Title: Extensions
 NoSidebar: true
 RedirectFrom: addins
 ---
-@Html.Partial("_ExtensionsList", Documents["Extensions"])
+@Html.Partial("_ExtensionsPage", Documents["Extensions"])

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -51,8 +51,13 @@ NoGutter: true
         <div class="col-sm-4">
             <h3 class="no-anchor">Reliable</h3>
             <p>
-                Regardless if you're building on your own machine, or building on a CI system such as AppVeyor, Azure DevOps,
-                TeamCity or Jenkins, Cake is built to behave in the same way.
+                Regardless if you're building on your own machine, or building on a CI system such as
+                <a href="docs/integrations/build-systems/azure-pipelines">Azure Pipelines</a>,
+                <a href="docs/integrations/build-systems/github-actions">GitHub Actions</a>,
+                <a href="docs/integrations/build-systems/teamcity">TeamCity</a> or
+                <a href="docs/integrations/build-systems/jenkins">Jenkins</a>,
+                Cake is built to behave in the same way.
+                See <a href="docs/integrations/build-systems">Build Systems</a> for a full list.
             </p>
         </div>
         <div class="col-sm-4">


### PR DESCRIPTION
Add documentation for every build server Cake provides a build system integration containing a description mentioning the alias and provider type which is available out of the box, including a simple example. Additionally also lists all extensions which are available for a specific build system.

![image](https://user-images.githubusercontent.com/2190718/98453742-e35a8400-215c-11eb-84ac-4360b55effac.png)
