### PR TITLE
Cleanup categories

### DIFF
--- a/extensions/Cake.ArgumentBinder.yml
+++ b/extensions/Cake.ArgumentBinder.yml
@@ -7,9 +7,6 @@ Repository: https://github.com/cake-contrib/Cake.ArgumentBinder/
 Author: xforever1313
 Description: Bind Cake arguments to classes via Attributes
 Categories:
-- xforever1313
-- dotnet
-- c#
 - argument
 - binder
 - reflection


### PR DESCRIPTION
Cleanup categories for Cake.ArgumentBinder addin which are synced from nuget.org, but not really useful on Cake website 