### PR TITLE
Remove button to create discussions

### DIFF
--- a/input/community/discuss.md
+++ b/input/community/discuss.md
@@ -8,10 +8,7 @@ Description: Where to discuss about Cake
 [GitHub Discussions](https://github.com/cake-build/cake/discussions) is the place to connect with other community members about Cake.
 
 <a class="btn btn-primary btn-lg" href="https://github.com/cake-build/cake/discussions" target="_blank" role="button">
-    <i class="fa fa-comment"></i> Browse discussions
-</a>
-<a class="btn btn-primary btn-lg" href="https://github.com/cake-build/cake/discussions/category_choices" target="_blank" role="button">
-    <i class="fa fa-comments"></i> Start a new discussion
+    <i class="fa fa-comment"></i> Go to discussions
 </a>
 
 # Twitter

--- a/input/community/getting-help.md
+++ b/input/community/getting-help.md
@@ -8,10 +8,7 @@ Description: How to get help
 [GitHub Discussions](https://github.com/cake-build/cake/discussions) is the place to get in touch with the community if you get stuck with Cake.
 
 <a class="btn btn-primary btn-lg" href="https://github.com/cake-build/cake/discussions?discussions_q=category%3AQ%26A" target="_blank" role="button">
-    <i class="fa fa-search"></i> Browse questions & answers
-</a>
-<a class="btn btn-primary btn-lg" href="https://github.com/cake-build/cake/discussions/new?category_id=7859135" target="_blank" role="button">
-    <i class="fa fa-life-ring"></i> Create a new question
+    <i class="fa fa-search"></i> Go to questions & answers
 </a>
 
 # Stack Overflow


### PR DESCRIPTION
Remove button to create discussions since it requires users to be logged in to GitHub, otherwise a 404 appears