### PR TITLE
(GH-1233) Mark addins hosted in cake-contrib org

### DIFF
--- a/input/_Bottom.cshtml
+++ b/input/_Bottom.cshtml
@@ -9,6 +9,13 @@
     });
 </script>
 
+<!-- Tooltip initialization -->
+<script>
+    $(function () {
+        $('[data-toggle="tooltip"]').tooltip()
+    })
+</script>
+
 <!-- Anchor configuration -->
 <script>
     // Allow to set ".no-anchor" class to not have an anchor on an element.

--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -73,6 +73,12 @@
             <li>
                 <i class="fa fa-github"></i>
                 <a href="@repository" target="_blank">@repository.Replace("https://github.com/", string.Empty).TrimEnd('/')</a>
+                @if (repository.StartsWith("https://github.com/cake-contrib/"))
+                {
+                    <a href="/community/cake-contrib">
+                        <i class="fa fa-check-circle" data-toggle="tooltip" title="Source code hosted in cake-contrib organization"></i>
+                    </a>
+                }
             </li>
         </ul>
 

--- a/input/_ExtensionsList.cshtml
+++ b/input/_ExtensionsList.cshtml
@@ -43,6 +43,12 @@
                     <li>
                         <i class="fa fa-github"></i>
                         <a href="@repository" target="_blank">@repository.Replace("https://github.com/", string.Empty).TrimEnd('/')</a>
+                        @if (repository.StartsWith("https://github.com/cake-contrib/"))
+                        {
+                            <a href="/community/cake-contrib">
+                                <i class="fa fa-check-circle" data-toggle="tooltip" title="Source code hosted in cake-contrib organization"></i>
+                            </a>
+                        }
                     </li>
                     @if (!string.IsNullOrWhiteSpace(categories))
                     {


### PR DESCRIPTION
Mark addins hosted in cake-contrib org with an icon, tooltip and link to cake-contrib documentation.

The icon is a link to the cake-contrib documentation: 

![image](https://user-images.githubusercontent.com/2190718/99903969-3ccbc280-2cc8-11eb-819c-f467aaef98db.png)

![image](https://user-images.githubusercontent.com/2190718/99904025-aea40c00-2cc8-11eb-913e-ed61a103223d.png)

Fixes #1233 