### PR TITLE
Show summary of aliases class

### DIFF
--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -49,6 +49,16 @@
                                     addinAssembly.Contains(
                                         aliasDocument.Document(CodeAnalysisKeys.ContainingAssembly).String("Name") + ".dll")));
 
+            // Show summary of aliases class
+            var summary =
+                aliasClasses
+                    .Select(x => x.String(CodeAnalysisKeys.Summary))
+                    .FirstOrDefault(x => !string.IsNullOrEmpty(x));
+            @if(!string.IsNullOrWhiteSpace(summary))
+            {
+                <div>@Html.Raw(summary)</div>
+            }
+
             @Html.Partial(
                 "_AliasesList",
                 aliasClasses,


### PR DESCRIPTION
Add summary of aliases class to addin details page. This is currently shown on the DSL page, but issue, there is that it doesn't work when multiple extensions or an extension and built-in alias use the same category. Having this documentation on the extension page is a better fit.

![image](https://user-images.githubusercontent.com/2190718/99917763-a5d82800-2d12-11eb-8795-05a3e7b41cba.png)

Updating DSL page is out of scope for this PR and will be done with #1078.

Fixes #1239 