### PR TITLE
Link from reference page to extension details page

### DIFF
--- a/input/_AliasesList.cshtml
+++ b/input/_AliasesList.cshtml
@@ -38,6 +38,35 @@ else {
                     {
                         <tr>
                             <td>
+                                @* Determine if alias is from an addin *@
+                                @{
+                                    string extensionName = null;
+                                }
+                                @if(showAddinReference)
+                                {
+                                    IDocument assemblyDoc = alias.Doc.Document(CodeAnalysisKeys.ContainingAssembly);
+                                    if (assemblyDoc != null)
+                                    {
+                                        IDocument extension =
+                                            Documents["Extensions"]
+                                                .FirstOrDefault(x => 
+                                                    x.List<string>("Assemblies") != null &&
+                                                    x.List<string>("Assemblies")
+                                                        .Any(
+                                                            addinAssembly =>
+                                                                addinAssembly != null &&
+                                                                addinAssembly.Contains(
+                                                                    assemblyDoc.String(CodeAnalysisKeys.DisplayName)
+                                                                )));
+                                        extensionName = extension?.String("Name");
+                                    }
+                                }
+
+                                @if(extensionName != null)
+                                {
+                                    <i class="fa fa-puzzle-piece"></i>
+                                }
+                                
                                 @if(alias.MethodAlias)
                                 {
                                     <text>@Context.GetTypeLink(alias.Doc, false)</text>
@@ -46,20 +75,19 @@ else {
                                 {
                                     <text>@Context.GetTypeLink(alias.Doc, alias.Doc.String("Name"), false)</text>
                                 }
+
+                                @if(showAddinReference && extensionName != null)
+                                {
+                                    <text>
+                                        <br/>
+                                        <small>
+                                            <i>Alias from <a href="/extensions/@extensionName.ToLower().Replace(".", "-")/">@extensionName</a> addin</i>
+                                        </small>
+                                    </text>
+                                }
                             </td>
                             <td>
                                 @Html.Raw(alias.Doc.String(CodeAnalysisKeys.Summary))
-                               @if(showAddinReference)
-                                {
-                                    IDocument assemblyDoc = alias.Doc.Document(CodeAnalysisKeys.ContainingAssembly);
-                                    if(assemblyDoc != null)
-                                    {
-                                        <text>
-                                            <br/>
-                                            <small><i>Addin from @Context.GetTypeLink(assemblyDoc)</i></small>
-                                        </text>
-                                    }
-                                }
                             </td>
                         </tr>
                     }


### PR DESCRIPTION
For aliases from addins link to addin detail page instead of assembly API documentation in DSL page.

Before:

![image](https://user-images.githubusercontent.com/2190718/99919844-2ea99080-2d20-11eb-862e-e841db125cbf.png)

After:

![image](https://user-images.githubusercontent.com/2190718/99919862-454fe780-2d20-11eb-92e3-329ed18be1fc.png)
