### PR TITLE
(GH-1078) Replace Built-In / Addin splitting in DSL category list 

### DIFF
--- a/input/_AddinAlert.cshtml
+++ b/input/_AddinAlert.cshtml
@@ -4,24 +4,23 @@
 	IDocument containingAssembly = Model.Get<IDocument>("ContainingAssembly");
     if(containingAssembly != null)
     {
-        IDocument addin = Documents["Extensions"]
-            .FirstOrDefault(x => 
+        IDocument extension = Documents["Extensions"]
+            .FirstOrDefault(x =>
                 (
                     x.String("Type") == null ||
                     x.String("Type").Equals("Addin", StringComparison.OrdinalIgnoreCase)
-                ) && 
+                ) &&
                 x.List<string>("Assemblies")
                     ?.Any(y => y.Contains(containingAssembly.String(CodeAnalysisKeys.DisplayName))) == true);
         <div class="alert alert-info" role="alert">
-            <i class="fa fa-info-circle"></i> This content is part of a third party addin that is not supported by the Cake project.
-            @if(addin != null && !string.IsNullOrEmpty(addin.String("Repository")))
+            <i class="fa fa-info-circle"></i> This content is part of a third party extension that is not supported by the Cake project.
+            @if(extension != null && !string.IsNullOrEmpty(extension.String("Name")))
             {
-                string repository = addin.String("Repository");
-                if(!string.IsNullOrEmpty(repository))
+                string extensionName = extension.String("Name");
+                if(!string.IsNullOrEmpty(extensionName))
                 {
                     <text>
-                        For more information about this project, please visit 
-                        <a href="@(repository)" class="alert-link">@repository</a>.
+                        For more information about this extension see <a href="/extensions/@extensionName.ToLower().Replace(".", "-")/">@extensionName</a>.
                     </text>
                 }
             }

--- a/input/_DslLayout.cshtml
+++ b/input/_DslLayout.cshtml
@@ -1,11 +1,11 @@
 @{
-	Layout = "/_Master.cshtml";
+    Layout = "/_Master.cshtml";
 
-	ViewData[Keys.Title] = "Reference - " + Model.String(Keys.GroupKey);
+    ViewData[Keys.Title] = "Reference - " + Model.String(Keys.GroupKey);
 }
 
 @section Infobar {
-	<div id="infobar-headings"></div>
+    <div id="infobar-headings"></div>
 }
 
 @section Sidebar {
@@ -13,29 +13,70 @@
 }
 
 <section class="content-header">
-	<h1>@Model.String(Keys.GroupKey)</h1>
+    <h1>@Model.String(Keys.GroupKey) aliases</h1>
 </section>
 <section class="content">
     @{
-        IDocument containingClass = Model
-            .DocumentList(Keys.GroupDocuments)
-            .FirstOrDefault();
+        // Group aliases by addin
+        var aliasesGroupedByAssembly =
+            Model
+                .DocumentList(Keys.GroupDocuments)
+                .GroupBy(x => x.Document(CodeAnalysisKeys.ContainingAssembly)?.String(CodeAnalysisKeys.DisplayName))
+                .OrderBy(x => x.Key);
     }
-    @Html.Partial("_AddinAlert", containingClass)
 
-    @{
-        string summary = Model
-            .DocumentList(Keys.GroupDocuments)
-            .Select(x => x.String(CodeAnalysisKeys.Summary))
-            .FirstOrDefault(x => !string.IsNullOrEmpty(x));
-    }
-    @if(!string.IsNullOrWhiteSpace(summary))
+    @foreach(var group in aliasesGroupedByAssembly)
     {
-        <h1 id="Summary">Summary</h1>
-        <div>@Html.Raw(summary)</div>
-    }
+        // Determine addin name
+        var isAddin = !string.IsNullOrWhiteSpace(group.Key);
+        string addinName = null;
+        @if(isAddin)
+        {
+            IDocument extension =
+                Documents["Extensions"]
+                    .FirstOrDefault(x =>
+                        x.List<string>("Assemblies") != null &&
+                        x.List<string>("Assemblies")
+                            .Any(
+                                addinAssembly =>
+                                    addinAssembly != null &&
+                                    addinAssembly.Contains(group.Key)));
+            @if(extension != null)
+            {
+                addinName = $"{extension.String("Name")} addin";
+            }
+        }
 
-    @Html.Partial("_AliasesList", Model.DocumentList(Keys.GroupDocuments))
+        // Group heading
+        var groupHeading = addinName ?? "Built-In";
+        <h1 id='@groupHeading.Replace(" ", "-")'>@groupHeading</h1>
+
+        // Addin annotation
+        @if(isAddin)
+        {
+            @Html.Partial("_AddinAlert", group.FirstOrDefault())
+        }
+
+        // Summary
+        string summary =
+            group
+                .Select(x => x.String(CodeAnalysisKeys.Summary))
+                .FirstOrDefault(x => !string.IsNullOrEmpty(x));
+
+        @if(!string.IsNullOrWhiteSpace(summary))
+        {
+            <p>@Html.Raw(summary)</p>
+        }
+
+        // Alias list
+        @Html.Partial(
+            "_AliasesList",
+            group,
+            new ViewDataDictionary(ViewData)
+            {
+                    { "groupHeadingLevel", 2 }
+            })
+    }
 
     @RenderBody()
 </section>

--- a/input/_DslSidebar.cshtml
+++ b/input/_DslSidebar.cshtml
@@ -1,24 +1,20 @@
 @{
-    List<Tuple<string, IDocument, bool, bool>> categories = new List<Tuple<string, IDocument, bool, bool>>();        
+    // Group aliases by category
+    //  - Item1: GroupKey
+    //  - Item2: Group
+    List<Tuple<string, IDocument>> categories = new List<Tuple<string, IDocument>>();
     foreach(IDocument group in Documents.FromPipeline("DslAliases"))
     {
-        categories.Add(new Tuple<string, IDocument, bool, bool>(group.String(Keys.GroupKey), group,
-            group.DocumentList(Keys.GroupDocuments).Any(y => y.Document(CodeAnalysisKeys.ContainingAssembly) == null),
-            group.DocumentList(Keys.GroupDocuments).Any(y => y.Document(CodeAnalysisKeys.ContainingAssembly) != null)
+        categories.Add(
+            new Tuple<string, IDocument>(
+                group.String(Keys.GroupKey),
+                group
         ));
     }
 }
 
-<li class="header">Built-In</li>
-@foreach(Tuple<string, IDocument, bool, bool> category in categories.Where(x => x.Item3))
+@foreach(Tuple<string, IDocument> category in categories)
 {
     string selectedClass = category.Item1 == Model.String(Keys.GroupKey) ? "selected" : null;
-    <li class="@selectedClass"><a href="@Context.GetLink(category.Item2)">@category.Item1</a></li>        
-}
-
-<li class="header">Addins</li>
-@foreach(Tuple<string, IDocument, bool, bool> category in categories.Where(x => x.Item4))
-{
-    string selectedClass = category.Item1 == Model.String(Keys.GroupKey) ? "selected" : null;
-    <li class="@selectedClass"><a href="@Context.GetLink(category.Item2)">@category.Item1</a></li>        
+    <li class="@selectedClass"><a href="@Context.GetLink(category.Item2)">@category.Item1</a></li>
 }

--- a/input/dsl/index.cshtml
+++ b/input/dsl/index.cshtml
@@ -1,75 +1,18 @@
 Title: Reference
 NoSidebar: false
 ---
-@section Infobar {	
-	<div>
-        <h6>On This Page</h6>
-        <p><a href="#built-in">Built-In</a></p>
-        <p><a href="#addins">Addins</a></p>
-        <hr class="infobar-hidden" />
-    </div>
-}
-
-@section Sidebar {    
+@section Sidebar {
     @Html.Partial("_DslSidebar")
 }
 
-<p>This reference guide describes the various methods and properties which make up the Cake build language, or DSL. If you're looking for other kind of information, check out the <a href="/api">API reference</a> or the <a href="/docs">documentation</a>.</p>
+<p>
+    This reference guide describes the various methods and properties which make up the Cake build language, or DSL.
+</p>
 
-<p>The DSL is made up of <a href="/docs/fundamentals/aliases">script aliases</a>, that offers specific functionality within the context of a Cake build script. A script alias is an extension method for ICakeContext.</p>
+<p>
+    The DSL is made up of <a href="/docs/fundamentals/aliases">script aliases</a>, that offers specific functionality within the context of a Cake build script.
+</p>
 
-@{
-    List<Tuple<string, string, IDocument, bool, bool>> categories = new List<Tuple<string, string, IDocument, bool, bool>>();        
-    foreach(IDocument group in Documents.FromPipeline("DslAliases"))
-    {
-        string summary = group
-            .DocumentList(Keys.GroupDocuments)
-            .Select(x => x.String(CodeAnalysisKeys.Summary))
-            .FirstOrDefault(x => !string.IsNullOrEmpty(x)); 
-        categories.Add(new Tuple<string, string, IDocument, bool, bool>(group.String(Keys.GroupKey), summary, group,
-            group.DocumentList(Keys.GroupDocuments).Any(y => y.Document(CodeAnalysisKeys.ContainingAssembly) == null),            
-            group.DocumentList(Keys.GroupDocuments).Any(y => y.Document(CodeAnalysisKeys.ContainingAssembly) != null)
-        ));
-    }
-}
-<h1 id="built-in">Built-In</h1>
-<div class="box">
-    <div class="box-body no-padding table-responsive">
-        <table class="table table-striped table-hover two-cols-alt">
-            <thead>
-                <tr>
-                    <th>Category</th>
-                    <th>Summary</th>
-                </tr>
-            </thead>
-            @foreach(Tuple<string, string, IDocument, bool, bool> category in categories.Where(x => x.Item4))
-            {
-                <tr>
-                    <td><a href="@Context.GetLink(category.Item3)">@category.Item1</a></td>
-                    <td>@Html.Raw(category.Item2)</td>
-                </tr>
-            }
-        </table>
-    </div>
-</div>
-
-<h1 id="addins">Addins</h1>
-<div class="box">
-    <div class="box-body no-padding table-responsive">
-        <table class="table table-striped table-hover two-cols-alt">
-            <thead>
-                <tr>
-                    <th>Category</th>
-                    <th>Summary</th>
-                </tr>
-            </thead>
-            @foreach(Tuple<string, string, IDocument, bool, bool> category in categories.Where(x => x.Item5))
-            {
-                <tr>
-                    <td><a href="@Context.GetLink(category.Item3)">@category.Item1</a></td>
-                    <td>@Html.Raw(category.Item2)</td>
-                </tr>
-            }
-        </table>
-    </div>
-</div>
+<p>
+    Listed are aliases which are shipped with Cake, but also aliases which are part of community maintained <a href="/extensions">addins</a>.
+</p>


### PR DESCRIPTION
Replace Built-In / Addin splitting in DSL category list with listing aliases for every category grouped by Built-In / Addin. This solves several issues like having summaries only shown for Built-In or one addin, when they share the same category, or having the annotation block shown that content is from a specific addin, while not everything on the page was from this addin.

![image](https://user-images.githubusercontent.com/2190718/100194065-4ab25b00-2ef5-11eb-927c-f2cd9f840404.png)

Fixes #1078 