### PR TITLE
(GH-1262) nuget.cake: Prefer stable versions of packages over pre-release versions

### DIFF
--- a/nuget.cake
+++ b/nuget.cake
@@ -41,7 +41,7 @@ public static void DownloadPackage(this ICakeContext context, DirectoryPath exte
         where item?.catalogEntry?.listed ?? false
         let version = item?.catalogEntry?.version
         let nugetVersion = version is null ? null : NuGetVersion.Parse(version)
-        orderby nugetVersion
+        orderby !(nugetVersion?.IsPrerelease ?? false), nugetVersion
         select new
         {
             id = packageId,


### PR DESCRIPTION
This PR builds on top of #1261 which should be merged first.

| Test&nbsp;case | Package&nbsp;Name | Latest&nbsp;version | Before&nbsp;this&nbsp;PR | After&nbsp;this&nbsp;PR |
| --- | --- | --- | --- | --- |
| Package has only stable versions listed | [Cake.7zip](https://www.nuget.org/packages/Cake.7zip/0.7.1) | 0.7.1 | 0.7.1 | 0.7.1 |
| Package has both stable and pre-release versions listed, but pre-release is latest | [Cake.NSwag.Console](https://www.nuget.org/packages/Cake.NSwag.Console/0.2.0-unstable0000) | 0.2.0-unstable0000 | **0.2.0-unstable0000** | **0.1.1** |
| Package has both stable and pre-release versions listed, but stable is latest | [Cake.Issues.Reporting.Generic](https://www.nuget.org/packages/Cake.Issues.Reporting.Generic) | 0.9.0 | 0.9.0 | 0.9.0 |
| Package has only pre-release versions listed | [Cake.Vault](https://www.nuget.org/packages/Cake.Vault) | 0.0.6-alpha | 0.0.6-alpha | 0.0.6-alpha |

---

Closes #1262