### PR TITLE
(GH-184) Display info when add-in is pre-release & fix preprocessor directive

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -22,6 +22,12 @@ Pipelines.InsertBefore(Docs.Code, "Extensions",
             : null
     ),
     Meta(
+        "IsPrerelease",
+        FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.isprerelease").Exists
+            ? bool.Parse(FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.isprerelease").ReadAllText())
+            : false
+    ),
+    Meta(
         Keys.WritePath,
         new FilePath("extensions/" + @doc.String("Name").ToLower().Replace(".", "-") + "/index.html")
     ),

--- a/input/_UsageAddin.cshtml
+++ b/input/_UsageAddin.cshtml
@@ -3,6 +3,15 @@
 @{
     string nuget = Model.String("NuGet");
     string version = Model.String("Version");
+    bool isPrerelease = Model.Bool("isPrerelease");
+    string preReleaseQueryParam = isPrerelease ? "&prerelease" : string.Empty;
+}
+
+@if (isPrerelease)
+{
+    <div class="alert alert-info" role="alert">
+      <i class="fa fa-info-circle"></i> This is a prerelease version of @(nuget).
+    </div>
 }
 
 <ul class="nav nav-tabs">
@@ -15,7 +24,7 @@
 <div class="tab-content">
     <div id="directive" class="tab-pane fade in active">
         <p>
-<pre><code class="language-csharp hljs">#addin nuget:?package=@(nuget)&version=@(version)</code></pre>
+<pre><code class="language-csharp hljs">#addin nuget:?package=@(nuget)&version=@(version + preReleaseQueryParam)</code></pre>
         </p>
     </div>
     <div id="config" class="tab-pane fade">

--- a/nuget.cake
+++ b/nuget.cake
@@ -46,6 +46,7 @@ public static void DownloadPackage(this ICakeContext context, DirectoryPath exte
         {
             id = packageId,
             version = nugetVersion?.ToNormalizedString(),
+            isPrerelease = nugetVersion?.IsPrerelease,
             item?.packageContent
         }
     ).LastOrDefault();
@@ -98,6 +99,7 @@ public static void DownloadPackage(this ICakeContext context, DirectoryPath exte
     }
 
     context.FileWriteText(extensionDir.CombineWithFilePath($"{packageId}.version"), packageInfo.version);
+    context.FileWriteText(extensionDir.CombineWithFilePath($"{packageId}.isprerelease"), packageInfo.isPrerelease.GetValueOrDefault().ToString());
 
     context.Information("[{0}] done.", packageId);
 }


### PR DESCRIPTION
- [x] Display information alert when the add-in is a pre-release version
- [x] Include the `&prerelease` parameter in the preprocessor directive example

![image](https://user-images.githubusercontent.com/177608/100529956-b3822780-31c2-11eb-920d-4f6902322560.png)

---

Closes #184