### PR TITLE
Install .NET 5 RTM in build

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.100-rc.2.20479.15",
+        "version": "5.0.100",
         "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
Install .NET 5 RTM during build.

While actual build was already switched to .NET 5 with https://github.com/cake-build/website/pull/1260, this improves overall build time. 