### PR TITLE
Calculate & display the supported Cake versions for extensions

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -157,6 +157,10 @@ Task("GetExtensionPackages")
                 .Where(x => !string.IsNullOrEmpty(x.NuGet))
                 .Select(x => x.NuGet)
                 .ToArray());
+
+        context.CalcSupportedCakeVersions(extensionDir,
+            extensionSpecs
+                .ToDictionary(e => e.NuGet, e => e.TargetCakeVersion));
     });
 
 Task("Build")

--- a/config.wyam
+++ b/config.wyam
@@ -28,6 +28,12 @@ Pipelines.InsertBefore(Docs.Code, "Extensions",
             : false
     ),
     Meta(
+        "SupportedCakeVersions",
+        FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.supportedcakeversions").Exists
+            ? FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.supportedcakeversions").ReadAllText()
+            : null
+    ),
+    Meta(
         Keys.WritePath,
         new FilePath("extensions/" + @doc.String("Name").ToLower().Replace(".", "-") + "/index.html")
     ),

--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -12,6 +12,7 @@
     string author = Model.String("Author");
     string repository = Model.String("Repository");
     string version = Model.String("Version");
+    string supportedCakeVersions = Model.String("SupportedCakeVersions");
     string categories = (String.Join(" ", Model.List<string>("Categories").Select(x => $"<span class=\"badge badge-secondary\">{x}</span>")));
     var assemblies = Model.List<string>("Assemblies");
 }
@@ -76,6 +77,12 @@
             <li>
                 Latest version: @version
             </li>
+            @if (!string.IsNullOrWhiteSpace(supportedCakeVersions))
+            {
+            <li>
+                Supported Cake versions: @supportedCakeVersions
+            </li>
+            }
             <li>
                 <img src="/assets/img/nuget.png">
                 <a href="https://www.nuget.org/packages/@nuget" target="_blank">@nuget</a>

--- a/nuget.cake
+++ b/nuget.cake
@@ -1,9 +1,14 @@
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Polly&version=7.1.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=LitJson&version=0.13.0"
 #addin "nuget:https://api.nuget.org/v3/index.json??package=Cake.FileHelpers&version=3.3.0"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=NuGet.Versioning&version=5.7.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=NuGet.Protocol&version=5.7.0"
 
 using System.Net.Http;
+using System.Threading;
+using NuGet.Common;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGetRepository = NuGet.Protocol.Core.Types.Repository;
 using NuGet.Versioning;
 using Polly;
 
@@ -102,6 +107,115 @@ public static void DownloadPackage(this ICakeContext context, DirectoryPath exte
     context.FileWriteText(extensionDir.CombineWithFilePath($"{packageId}.isprerelease"), packageInfo.isPrerelease.GetValueOrDefault().ToString());
 
     context.Information("[{0}] done.", packageId);
+}
+
+// Cake compatilibity ranges derived from `LatestPotentialBreakingChange`
+// Version range values use interval notation
+// https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges
+static VersionRange[] _compatibilityVersionRanges = new []
+{
+    "[1.0.0, )",
+    "[0.33.0, 1.0.0)",
+    "[0.28.0, 0.33.0)",
+    "[0.26.0, 0.28.0)",
+    "[0.22.0, 0.26.0)",
+    "[0.16.0, 0.22.0)",
+    "[0.15.0, 0.16.0)",
+    "[0.14.0, 0.15.0)",
+    "[0.13.0, 0.14.0)",
+    "[0.12.0, 0.13.0)",
+    "[0.11.0, 0.12.0)",
+    "[0.10.0, 0.11.0)",
+    "[0.9.0, 0.10.0)",
+    "[0.8.0, 0.9.0)",
+    "[0.7.0, 0.8.0)",
+    "[0.6.0, 0.7.0)",
+    "[0.5.0, 0.6.0)",
+    "[0.4.0, 0.5.0)",
+    "[0.3.0, 0.4.0)",
+    "[0.2.0, 0.3.0)",
+    "[0.1.0, 0.2.0)",
+    "[0.0.0, 0.1.0)",
+}
+.Select(r => VersionRange.Parse(r))
+.OrderByDescending(r => r.MinVersion)
+.ToArray();
+
+public static void CalcSupportedCakeVersions(this ICakeContext context, DirectoryPath extensionDir, IDictionary<string, string> packageVersionLookup)
+{
+    var allListedCakeVersions = GetAllListedCakeVersions();
+
+    foreach (var item in packageVersionLookup)
+    {
+        var packageId = item.Key;
+        var targetCakeVersion = item.Value is null ? null : new NuGetVersion(item.Value);
+
+        var supportedCakeVersions = CalcSupportedCakeVersionsForExtension(targetCakeVersion, allListedCakeVersions);
+        context.FileWriteText(extensionDir.CombineWithFilePath($"{packageId}.supportedcakeversions"), supportedCakeVersions);
+    }
+}
+
+static IReadOnlyList<NuGetVersion> GetAllListedCakeVersions()
+{
+    using (var cacheContext = new SourceCacheContext { NoCache = true })
+    {
+        var repository = NuGetRepository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+
+        var resource = repository.GetResourceAsync<PackageMetadataResource>().GetAwaiter().GetResult();
+
+        var packages = resource.GetMetadataAsync("Cake", includePrerelease: true,
+            includeUnlisted: true, cacheContext, NullLogger.Instance, CancellationToken.None).GetAwaiter().GetResult();
+
+        var allVersionsOfCake = packages.OfType<PackageSearchMetadataRegistration>()
+            .OrderByDescending(p => p.Version)
+            .Select(p => p.Version)
+            .ToList();
+
+        return allVersionsOfCake;
+    }
+}
+
+static string CalcSupportedCakeVersionsForExtension(NuGetVersion extensionVersion, IReadOnlyList<NuGetVersion> allListedCakeVersions)
+{
+    if (extensionVersion is null) return null;
+
+    // Map AddInDiscoverer's TargetCakeVersion to a listed Cake version
+    // (edge case if core libraries are released separately from the Cake package)
+    var minCakeVersion = allListedCakeVersions
+        .Where(v => v >= extensionVersion && v.IsPrerelease == extensionVersion.IsPrerelease)
+        .OrderBy(v => v)
+        .FirstOrDefault();
+
+    if (minCakeVersion is null)
+    {
+        // Extension seems to reference a version of Cake that is not listed
+        return null;
+    }
+
+    NuGetVersion maxCakeVersion = null;
+    if (minCakeVersion.IsPrerelease)
+    {
+        // Extensions targeting pre-release versions of Cake are pinned to the specific pre-release version they target
+        return $"{minCakeVersion}";
+    }
+    else
+    {
+        // Find the latest compatibility range that this extension falls into
+        var compatRange = _compatibilityVersionRanges
+            .Where(r => r.Satisfies(minCakeVersion))
+            .OrderByDescending(r => r.MinVersion)
+            .First();
+
+        // Find the maximum stable Cake version that satisfies the compat range
+        maxCakeVersion = allListedCakeVersions
+            .Where(v => compatRange.Satisfies(v) && !v.IsPrerelease)
+            .OrderByDescending(v => v)
+            .First();
+    }
+
+    return (minCakeVersion == maxCakeVersion)
+        ? $"{maxCakeVersion}"
+        : $"{minCakeVersion} - {maxCakeVersion}";
 }
 
 public class Package


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/177608/100830417-fb5eb400-3439-11eb-89d8-438887689c5c.png)

As per discussion on [#299](https://github.com/cake-build/website/issues/299#issuecomment-736385702) this is how I'm calculating the supported versions of a Cake add-in in this PR:

#### Add-ins targeting stable versions of Cake (i.e. not pre-release)

1. Read the [`TargetCakeVersion`](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.7zip.yml#L11) populated by the AddinDiscoverer, which is [derived](https://github.com/cake-build/website/issues/299#issuecomment-720156460) from the version of `Cake.Core` or `Cake.Common` that an add-in targets

2. Determine the **minimum Cake compatible version** by mapping the `TargetCakeVersion` to a corresponding version of the [Cake package](https://www.nuget.org/packages/Cake/) to one of the listed versions of the Cake package (_edge case if a version of Cake is unlisted, or if core libraries are released separately from the Cake package_)

3. Determine the highest compatibility range that the add-in falls into based on a [lookup table of version ranges derived from the `LatestPotentialBreakingChange`](https://github.com/cake-build/website/issues/299#issuecomment-736385702)

4. Determine the **maximum Cake compatible version** from the highest listed [Cake](https://www.nuget.org/packages/Cake/) version that satisfies the highest compatibility range the add-in falls into

---

#### Add-ins targeting pre-release versions of Cake

1. (_Same as step 1 above_)

2. (_Same as step 2 above_)

3. Assume that the add-in is only compatible with the specific minimum version of Cake (pre-release) determined on step 2. e.g. an add-in targeting Cake `1.0.0-rc0001` will show on the website as compatible only with Cake `1.0.0-rc0001` (pinned). _This is what made sense to me, but happy to change if it's too conservative_.

---

I sampled one add-in of each version that is currently tracked, and here are the supported Cake versions assigned to each one:

| Sample Package | TargetCakeVersion | | SupportedCakeVersions |
| --- |:---:|:---:|:---:|
| [Cake.MinVer](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.MinVer.yml) (\*) | 1.0.0-rc0001 | :arrow_right: | 1.0.0-rc0001 |
| [Cake.ArgumentBinder](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.ArgumentBinder.yml) | 0.38.5 | :arrow_right: | 0.38.5 |
| [Cake.WinSCP](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.WinSCP.yml) | 0.38.4 | :arrow_right: | 0.38.4 - 0.38.5 |
| [Cake.CoverageComparer](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.CoverageComparer.yml) | 0.38.2 | :arrow_right: | 0.38.2 - 0.38.5 |
| [Cake.NScan](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.NScan.yml) | 0.38.1 | :arrow_right: | 0.38.1 - 0.38.5 |
| [Cake.ApiReference.Uploader](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.ApiReference.Uploader.yml) | 0.37.0 | :arrow_right: | 0.37.0 - 0.38.5 |
| [Cake.Coverlet](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.Coverlet.yml) | 0.36.0 | :arrow_right: | 0.36.0 - 0.38.5 |
| [Cake.Azure](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.Azure.yml) | 0.35.0 | :arrow_right: | 0.35.0 - 0.38.5 |
| [Cake.Board.Asana](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.Board.Asana.yml) | 0.34.1 | :arrow_right: | 0.34.1 - 0.38.5 |
| [Cake.Fastlane](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.Fastlane.yml) | 0.34.0 | :arrow_right: | 0.34.0 - 0.38.5 |
| [Cake.7zip](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.7zip.yml) | 0.33.0 | :arrow_right: | 0.33.0 - 0.38.5 |
| [Cake.XmlDoc.Checker](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.XmlDoc.Checker.yml) | 0.32.1 | :arrow_right: | 0.32.1 |
| [Cake.Debootstrap](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.Debootstrap.yml) | 0.30.0 | :arrow_right: | 0.30.0 - 0.32.1 |
| [Cake.MiniCover](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.MiniCover.yml) | 0.29.0 | :arrow_right: | 0.29.0 - 0.32.1 |
| [Cake.ArgumentHelpers](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.ArgumentHelpers.yml) | 0.28.1 | :arrow_right: | 0.28.1 - 0.32.1 |
| [Cake.GitPackager](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.GitPackager.yml) | 0.28.0 | :arrow_right: | 0.28.0 - 0.32.1 |
| [Cake.DependenciesAnalyser](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.DependenciesAnalyser.yml) | 0.27.1 | :arrow_right: | 0.27.1 - 0.27.2 |
| [Cake.AssemblyInfoReflector](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.AssemblyInfoReflector.yml) | 0.26.1 | :arrow_right: | 0.26.1 - 0.27.2 |
| [Cake.DocumentDb](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.DocumentDb.yml) | 0.26.0 | :arrow_right: | 0.26.0 - 0.27.2 |
| [Cake.HandlebarsDotNet](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.HandlebarsDotNet.yml) | 0.25.0 | :arrow_right: | 0.25.0 |
| [Cake.AWS.ElasticBeanstalk](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.AWS.ElasticBeanstalk.yml) | 0.23.0 | :arrow_right: | 0.23.0 - 0.25.0 |
| [Cake.DependencyCheck](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.DependencyCheck.yml) | 0.22.0 | :arrow_right: | 0.22.0 - 0.25.0 |
| [Cake.RSync](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.RSync.yml) | 0.21.1 | :arrow_right: | 0.21.1 |
| [Cake.ClickTwice](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.ClickTwice.yml) | 0.19.5 | :arrow_right: | 0.19.5 - 0.21.1 |
| [Cake.DocCreator](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.DocCreator.yml) | 0.19.4 | :arrow_right: | 0.19.4 - 0.21.1 |
| [Cake.AutoRest](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.AutoRest.yml) | 0.18.0 | :arrow_right: | 0.18.0 - 0.21.1 |
| [Cake.ActiveDirectory](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.ActiveDirectory.yml) | 0.17.0 | :arrow_right: | 0.17.0 - 0.21.1 |
| [Cake.Gradle](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.Gradle.yml) | 0.15.2 | :arrow_right: | 0.15.2 |
| [Cake.SimpleHTTPServer](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.SimpleHTTPServer.yml) | 0.13.0 | :arrow_right: | 0.13.0 |
| [Cake.ViewCompiler](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.ViewCompiler.yml) | 0.10.1 | :arrow_right: | 0.10.1 |
| [Cake.CakeBoss](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/Cake.CakeBoss.yml) | 0.6.4 | :arrow_right: | 0.6.4 |
| [MagicChunks](https://github.com/cake-build/website/blob/d12f7954c0707990b17f219e99c286b22eb090d1/extensions/MagicChunks.yml) | `null` | :arrow_right: |  |

NB: When unable to determine the supported Cake versions it won't display the "Supported Cake versions" item on the website. `MagicChunks` is an example of an extension that doesn't have a value assigned for `TargetCakeVersion` at the moment (will be fixed by #1287).

(\*) The AddinDiscoverer doesn't yet support pre-release versions when populating the `TargetCakeVersion` and [will be fixed soon](https://github.com/cake-contrib/Cake.AddinDiscoverer/issues/140). More details on https://github.com/cake-build/website/pull/1285

---

- Closes #299
- Relates to #580
