### PR TITLE
Add documentation for VS Code extension

### DIFF
--- a/input/docs/integrations/editors/vscode/index.cshtml
+++ b/input/docs/integrations/editors/vscode/index.cshtml
@@ -4,4 +4,78 @@ Description: Extensions and supported features for Visual Studio Code
 RedirectFrom: docs/editors/vscode
 ---
 
+<p>
+    The <a href="https://marketplace.visualstudio.com/items/cake-build.cake-vscode" target="_blank">Cake extension for Visual Studio Code</a>
+    brings the following features to Visual Studio Code:
+    <ul>
+        <li><a href="#commands">Commands</a> for working with Cake files</li>
+        <li>Language support for Cake build scripts</li>
+        <li>Support for code outline and breadcrumb navigation in Cake files</li>
+        <li>Integration to run Cake tasks via the built in `Tasks: Run Task` command</li>
+        <li>CodeLens to allow you to run and debug tasks</li>
+        <li><a href="/docs/integrations/editors/vscode/snippets">Snippets</a></li>
+    </ul>
+</p>
+
+<h1>Installation & configuration</h1>
+
+See <a href="https://marketplace.visualstudio.com/items/cake-build.cake-vscode" target="_blank">Cake extension for Visual Studio Code</a> for instructions how to install and configure the extension.
+
+<h1>Commands</h1>
+
+<p>
+    In addition to integrated editing features, the extension also provides the following commands in the Command Palette for working with Cake files:
+</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Command</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Cake: Install a bootstrapper</td>
+            <td>Installs a Cake bootstrapper for Windows, macOS or Linux in the root folder.</td>
+        </tr>
+        <tr>
+            <td>Cake: Install to workspace</td>
+            <td>Will run through all of the available commands at once, to save having to run them one by one.</td>
+        </tr>
+        <tr>
+            <td>Cake: Install debug dependencies</td>
+            <td>Installs either the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET tool</a> globally or alternatively download the <a href="/docs/running-builds/runners/cake-runner-for-dotnet-core">Cake runner for .NET Core</a> into the <code>tools</code> folder.</td>
+        </tr>
+        <tr>
+            <td>Cake: Install sample build file</td>
+            <td>Installs a sample Cake file that contains setup and teardown actions, a sample task, and argument parsing.</td>
+        </tr>
+        <tr>
+            <td>Cake: Add addin from NuGet</td>
+            <td>Add or update an addin from NuGet in the specified Cake file.</td>
+        </tr>
+        <tr>
+            <td>Cake: Add tool from NuGet</td>
+            <td>Add or update a tool from NuGet in the specified Cake file.</td>
+        </tr>
+        <tr>
+            <td>Cake: Add module from NuGet</td>
+            <td>Add or update a module from NuGet in the modules <code>package.config</code>.</td>
+        </tr>
+        <tr>
+            <td>Cake: Install a configuration file</td>
+            <td>Installs the default Cake configuration file for controlling internal components of Cake.</td>
+        </tr>
+        <tr>
+            <td>Cake: Install intellisense support</td>
+            <td>
+                Downloads the Cake.Bakery NuGet Package into the tools folder, which in conjunction with OmniSharp provides IntelliSense support for Cake Files.
+                See <a href="/docs/integrations/editors/vscode/intellisense">IntelliSense in Visual Studio Code</a> for details.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<h1>Child pages</h1>
+
 @Html.Partial("_ChildPages")

--- a/input/docs/integrations/editors/vscode/intellisense.md
+++ b/input/docs/integrations/editors/vscode/intellisense.md
@@ -1,4 +1,4 @@
-Order: 10
+Order: 20
 Title: IntelliSense in Visual Studio Code
 Description: Support for IntelliSense
 RedirectFrom: docs/editors/vscode/intellisense

--- a/input/docs/integrations/editors/vscode/resources.md
+++ b/input/docs/integrations/editors/vscode/resources.md
@@ -1,4 +1,4 @@
-Order: 30
+Order: 40
 Title: Visual Studio Code resources
 Description: Resources about Visual Studio Code support
 RedirectFrom: docs/editors/vscode/resources

--- a/input/docs/integrations/editors/vscode/snippets.md
+++ b/input/docs/integrations/editors/vscode/snippets.md
@@ -1,8 +1,10 @@
-Order: 20
+Order: 30
 Title: Visual Studio Code snippets
 Description: Support for code snippets
 RedirectFrom: docs/editors/vscode/snippets
 ---
+
+# Configuring snippets
 
 <ul class="nav nav-tabs">
     <li class="active"><a data-toggle="tab" href="#tool">Cake .NET Tool</a></li>
@@ -48,6 +50,40 @@ RedirectFrom: docs/editors/vscode/snippets
         </div>
     </div>
 </div>
+
+# Available snippets
+
+* `cake-addin`
+  * Provides a basic addin pre-processor directive, where the package name and version can be changed
+  * _Default Value:_ `#addin "nuget:?package=Cake.Foo&version=1.2.3"`
+* `cake-addin-full`
+  * Provides a more complete addin pre-processor directive, where source, package name and version can be changed
+  * _Default Value:_ `#addin "nuget:https://www.nuget.org/api/v2?package=Cake.Foo&version=1.2.3"`
+* `cake-argument`
+  * Provides code for basic input argument parsing, where variable name, argument name and default value can be changed
+  * _Default Value:_ `var target = Argument("target", "Default");`
+* `cake-load`
+  * Provides a basic load pre-processor directive, where the path to the .cake file can be changed
+  * _Default Value:_ `#load "scripts/utilities.cake"`
+* `cake-load-nuget`
+  * Provides a more complex load pre-processor directive, where source, package name and version can be changed
+  * _Default Value:_ `#load "nuget:https://www.nuget.org/api/v2?package=Cake.Foo&version=1.2.3"`
+* `cake-reference`
+  * Provides a basic reference pre-processor directive, where path to the assembly can be changed
+  * _Default Value:_ `#reference "bin/myassembly.dll"`
+* `cake-sample`
+  * Provides a complete sample build Cake script including setup and teardown actions, a single task, and argument parsing
+* `cake-tool`
+  * Provides a basic tool pre-processor directive, where the package name and version can be changed
+  * _Default Value:_ `#tool "nuget:?package=Cake.Foo&version=1.2.3"`
+* `cake-tool-full`
+  * Provides a more complete tool pre-processor directive, where source, package name and version can be changed
+  * _Default Value:_ `#tool "nuget:https://www.nuget.org/api/v2?package=Cake.Foo&version=1.2.3"`
+* `task`
+  * Provides a basic task definition, where the name of the task can be changed
+  * _Default Value:_ `Task("name");`
+* `task` (With Action)
+  * Provides a more complex task definition, including an `.Does` body, where the name of the task can be changed
 
 [Cake extension for Visual Studio Code]: https://marketplace.visualstudio.com/items/cake-build.cake-vscode
 [Extension Marketplace documentation]: https://code.visualstudio.com/docs/editor/extension-gallery


### PR DESCRIPTION
Add documentation for VS Code extension. 

I decided to not add configuration options documented in https://marketplace.visualstudio.com/items?itemName=cake-build.cake-vscode, but instead linking to marketplace, since I think it's a better place to be documented there (and on the extension page in Visual Studio Code). I copied commands and snippets, but if prefered to keep everything on a single place I can also replace them with links to the marketplace page.