### PR TITLE
GH-1294: Display addin AnalyzedPackageVersion YAML instead of the version determined via build

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -16,12 +16,6 @@ Pipelines.InsertBefore(Docs.Code, "Extensions",
     ReadFiles("../extensions/*.yml"),
     Yaml(),
     Meta(
-        "Version",
-        FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.version").Exists
-            ? FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.version").ReadAllText()
-            : null
-    ),
-    Meta(
         "IsPrerelease",
         FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.isprerelease").Exists
             ? bool.Parse(FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.isprerelease").ReadAllText())

--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -11,7 +11,7 @@
     string description = Model.String("Description");
     string author = Model.String("Author");
     string repository = Model.String("Repository");
-    string version = Model.String("Version");
+    string version = Model.String("AnalyzedPackageVersion");
     string supportedCakeVersions = Model.String("SupportedCakeVersions");
     string categories = (String.Join(" ", Model.List<string>("Categories").Select(x => $"<span class=\"badge badge-secondary\">{x}</span>")));
     var assemblies = Model.List<string>("Assemblies");

--- a/input/_ExtensionsList.cshtml
+++ b/input/_ExtensionsList.cshtml
@@ -21,7 +21,7 @@
         string description = extension.String("Description");
         string author = extension.String("Author");
         string repository = extension.String("Repository");
-        string version = extension.String("Version");
+        string version = extension.String("AnalyzedPackageVersion");
         string categories = (String.Join(", ", extension.List<string>("Categories")));
 
         <article class="extension row" data-name="@name" data-categories="@categories">

--- a/input/_UsageAddin.cshtml
+++ b/input/_UsageAddin.cshtml
@@ -2,7 +2,7 @@
 
 @{
     string nuget = Model.String("NuGet");
-    string version = Model.String("Version");
+    string version = Model.String("AnalyzedPackageVersion");
     bool isPrerelease = Model.Bool("isPrerelease");
     string preReleaseQueryParam = isPrerelease ? "&prerelease" : string.Empty;
 }

--- a/nuget.cake
+++ b/nuget.cake
@@ -103,7 +103,6 @@ public static void DownloadPackage(this ICakeContext context, DirectoryPath exte
         }
     }
 
-    context.FileWriteText(extensionDir.CombineWithFilePath($"{packageId}.version"), packageInfo.version);
     context.FileWriteText(extensionDir.CombineWithFilePath($"{packageId}.isprerelease"), packageInfo.isPrerelease.GetValueOrDefault().ToString());
 
     context.Information("[{0}] done.", packageId);


### PR DESCRIPTION
As per @pascalberger's https://github.com/cake-build/website/issues/1294#issuecomment-744005408

> Addin discoverer now maintains analyzed version of addin in the YAML file. We should update Website code to use this version of the addin and remove code for determine addin version from website build
