### PR TITLE
(GH-1195) Add support for project URL to extension metadata

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -43,6 +43,7 @@ class ExtensionSpec
     public string NuGet { get; set; }
     public List<string> Assemblies { get; set; }
     public string Repository { get; set; }
+    public string ProjectUrl { get; set; }
     public string Author { get; set; }
     public string Description { get; set; }
     public List<string> Categories { get; set; }


### PR DESCRIPTION
Add support for project URL to extension metadata

Part of #1195 