### PR TITLE
(GH-580) Add target framework versions to extension metadata

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -48,6 +48,7 @@ class ExtensionSpec
     public List<string> Categories { get; set; }
     public string AnalyzedPackageVersion { get; set; }
     public string TargetCakeVersion { get; set; }
+    public List<string> TargetFrameworks { get; set; }
 }
 
 // Variables


### PR DESCRIPTION
Add support for target framework versions to extension metadata.

Part of #580