### PR TITLE
GH-1153: Show aliases without ICakeContext extension parameter (also when it's the only arg)

### DIFF
--- a/input/_AliasesList.cshtml
+++ b/input/_AliasesList.cshtml
@@ -103,7 +103,9 @@ else {
     public HtmlString GetAliasTypeLink(IMetadata metadata, bool linkTypeArguments)
     {
         var link = Context.GetTypeLink(metadata, linkTypeArguments);
-        var encodedHtml = link.Value?.Replace("(ICakeContext, <wbr>", "(");
+        var encodedHtml = link.Value?
+            .Replace("(ICakeContext, <wbr>", "(")
+            .Replace("(ICakeContext)", "()");
 
         return new HtmlString(encodedHtml);
     }


### PR DESCRIPTION
I missed a case in PR #1359 where `ICakeContext` is the only argument of the method - and in that case it still shows in the documentation.

As an example, the [Azure DevOps add-in](https://cakebuild.net/dsl/azure-devops/) at the moment shows:

![image](https://user-images.githubusercontent.com/177608/102150965-1bce3b80-3e48-11eb-9678-7bb28c9c83f4.png)

---

But should be:

![image](https://user-images.githubusercontent.com/177608/102150974-22f54980-3e48-11eb-9fa8-b9fbf0a0f400.png)
