### PR TITLE
(GH-1280) Add field for compliance score of extensions

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -50,6 +50,7 @@ class ExtensionSpec
     public string AnalyzedPackageVersion { get; set; }
     public string TargetCakeVersion { get; set; }
     public List<string> TargetFrameworks { get; set; }
+    public int ComplianceScore { get; set; }
 }
 
 // Variables


### PR DESCRIPTION
Add field to extension yaml files for a compliance score (0-100) which indicates how well an extension follows best practices (support for latest Cake version, all supported runners, etc). Number can later be calculated and maintained by Addin Discoverer which already has all the required information about every addin.

`ComplianceNotes` can be used to pass human readable information how the compliance score was calculated (e.g. "Does not work with Cake runner for .NET Framework", "Works with latest Cake version".

Part of #1280 