### PR TITLE
(GH-1280) Add field for notes to compliance score

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -53,6 +53,7 @@ class ExtensionSpec
     public string TargetCakeVersion { get; set; }
     public List<string> TargetFrameworks { get; set; }
     public int ComplianceScore { get; set; }
+    public List<string> ComplianceNotes { get; set; }
 }
 
 // Variables


### PR DESCRIPTION
`ComplianceNotes` can be used to pass human readable information how the compliance score was calculated (e.g. "Does not work with Cake runner for .NET Framework", "Works with latest Cake version".

Part of #1280 