### PR TITLE
(GH-1294) Add flag if extension version is pre-release

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -49,6 +49,7 @@ class ExtensionSpec
     public List<string> Categories { get; set; }
     public string AnalyzedPackageVersion { get; set; }
     public string AnalyzedPackagePublishDate { get; set; }
+    public bool AnalyzedPackageIsPrerelease { get; set; }
     public string TargetCakeVersion { get; set; }
     public List<string> TargetFrameworks { get; set; }
     public int ComplianceScore { get; set; }


### PR DESCRIPTION
Add a flag which says if the version in `AnalyzedPackageVersion` is a pre-release version or not. 

Part of #1294