### PR TITLE
Update display of repository URL

### DIFF
--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -88,16 +88,19 @@
                 <img src="/assets/img/nuget.png">
                 <a href="https://www.nuget.org/packages/@nuget" target="_blank">@nuget</a>
             </li>
-            <li>
-                <i class="fa fa-github"></i>
-                <a href="@repository" target="_blank">@repository.Replace("https://github.com/", string.Empty).TrimEnd('/')</a>
-                @if (repository.StartsWith("https://github.com/cake-contrib/"))
-                {
-                    <a href="/community/cake-contrib">
-                        <i class="fa fa-check-circle" data-toggle="tooltip" title="Source code hosted in cake-contrib organization"></i>
-                    </a>
-                }
-            </li>
+            @if (!string.IsNullOrWhiteSpace(repository))
+            {
+                <li>
+                    <i class="fa fa-github"></i>
+                    <a href="@repository" target="_blank">@GetRepositoryLinkName(repository)</a>
+                    @if (repository.StartsWith("https://github.com/cake-contrib/"))
+                    {
+                        <a href="/community/cake-contrib">
+                            <i class="fa fa-check-circle" data-toggle="tooltip" title="Source code hosted in cake-contrib organization"></i>
+                        </a>
+                    }
+                </li>
+            }
         </ul>
 
         <h2 class="no-anchor">Authors</h2>
@@ -111,3 +114,16 @@
         </p>
     </aside>
 </section>
+
+@functions
+{
+    public string GetRepositoryLinkName(string repository)
+    {
+        if (repository.EndsWith(".git"))
+        {
+            repository = repository.Remove(repository.LastIndexOf(".git"));
+        }
+
+        return repository.Replace("https://github.com/", string.Empty).TrimEnd('/');
+    }
+}

--- a/input/_ExtensionsList.cshtml
+++ b/input/_ExtensionsList.cshtml
@@ -20,7 +20,6 @@
         string name = extension.String("Name");
         string description = extension.String("Description");
         string author = extension.String("Author");
-        string repository = extension.String("Repository");
         string version = extension.String("AnalyzedPackageVersion");
         string categories = (String.Join(", ", extension.List<string>("Categories")));
 
@@ -39,16 +38,6 @@
                 <ul class="extension-metadata">
                     <li>
                         Latest version: @version
-                    </li>
-                    <li>
-                        <i class="fa fa-github"></i>
-                        <a href="@repository" target="_blank">@repository.Replace("https://github.com/", string.Empty).TrimEnd('/')</a>
-                        @if (repository.StartsWith("https://github.com/cake-contrib/"))
-                        {
-                            <a href="/community/cake-contrib">
-                                <i class="fa fa-check-circle" data-toggle="tooltip" title="Source code hosted in cake-contrib organization"></i>
-                            </a>
-                        }
                     </li>
                     @if (!string.IsNullOrWhiteSpace(categories))
                     {


### PR DESCRIPTION
Hides the repo URL from the extension list in preparation for https://github.com/cake-build/website/issues/1367 which provides update date for extensions, which is a much more interesting information in a list of extensions. 
Also handles the case where an addin don't has a repository URL and removes the `.git` suffix from the repo link name.