### PR TITLE
(GH-1367) Add publish date of extensions

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -1,3 +1,7 @@
+#n Humanizer.Core
+
+System.Globalization.CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-GB");
+
 ContentStreamFactory = new MemoryContentStreamFactory();
 
 Settings[Keys.Host] = "cakebuild.net";

--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -1,3 +1,5 @@
+@using Humanizer;
+
 @{
     Layout = "/_Master.cshtml";
 
@@ -12,6 +14,7 @@
     string author = Model.String("Author");
     string repository = Model.String("Repository");
     string version = Model.String("AnalyzedPackageVersion");
+    string publishDate = Model.String("AnalyzedPackagePublishDate");
     string supportedCakeVersions = Model.String("SupportedCakeVersions");
     string categories = (String.Join(" ", Model.List<string>("Categories").Select(x => $"<span class=\"badge badge-secondary\">{x}</span>")));
     var assemblies = Model.List<string>("Assemblies");
@@ -77,6 +80,17 @@
             <li>
                 Latest version: @version
             </li>
+            @if (!string.IsNullOrWhiteSpace(publishDate))
+            {
+                var parsedPublishDate = @DateTime.Parse(publishDate, null, System.Globalization.DateTimeStyles.RoundtripKind);
+
+                <li>
+                    <span title="@parsedPublishDate.ToOrdinalWords()">
+                        <i class="fa fa-clock-o"></i>
+                        Last updated @parsedPublishDate.Humanize()
+                    </span>
+                </li>
+            }
             @if (!string.IsNullOrWhiteSpace(supportedCakeVersions))
             {
             <li>

--- a/input/_ExtensionsList.cshtml
+++ b/input/_ExtensionsList.cshtml
@@ -1,4 +1,7 @@
+
 @model IEnumerable<IDocument>
+
+@using Humanizer;
 
 @{
     var extensions =
@@ -21,6 +24,7 @@
         string description = extension.String("Description");
         string author = extension.String("Author");
         string version = extension.String("AnalyzedPackageVersion");
+        string publishDate = extension.String("AnalyzedPackagePublishDate");
         string categories = (String.Join(", ", extension.List<string>("Categories")));
 
         <article class="extension row" data-name="@name" data-categories="@categories">
@@ -39,6 +43,17 @@
                     <li>
                         Latest version: @version
                     </li>
+                    @if (!string.IsNullOrWhiteSpace(publishDate))
+                    {
+                        var parsedPublishDate = @DateTime.Parse(publishDate, null, System.Globalization.DateTimeStyles.RoundtripKind);
+
+                        <li>
+                            <span title="@parsedPublishDate.ToOrdinalWords()">
+                                <i class="fa fa-clock-o"></i>
+                                Last updated @parsedPublishDate.Humanize()
+                            </span>
+                        </li>
+                    }
                     @if (!string.IsNullOrWhiteSpace(categories))
                     {
                         <li>


### PR DESCRIPTION
Shows the publish date of last version of extension in the extension list and details page.

![image](https://user-images.githubusercontent.com/2190718/102700249-fed0a880-424b-11eb-9bac-f80a160bcd24.png)

Fixes #1367 