### PR TITLE
Use fix titles for links

### DIFF
--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -103,7 +103,7 @@
             {
                 <li>
                     <i class="fa fa-globe"></i>
-                    <a href="@projectUrl" target="_blank">@projectUrl</a>
+                    <a href="@projectUrl" target="_blank">Project Site</a>
                 </li>
             }
             <li>
@@ -114,7 +114,7 @@
             {
                 <li>
                     <i class="fa fa-github"></i>
-                    <a href="@repository" target="_blank">@GetRepositoryLinkName(repository)</a>
+                    <a href="@repository" target="_blank">Source repository</a>
                     @if (repository.StartsWith("https://github.com/cake-contrib/"))
                     {
                         <a href="/community/cake-contrib">
@@ -136,16 +136,3 @@
         </p>
     </aside>
 </section>
-
-@functions
-{
-    public string GetRepositoryLinkName(string repository)
-    {
-        if (repository.EndsWith(".git"))
-        {
-            repository = repository.Remove(repository.LastIndexOf(".git"));
-        }
-
-        return repository.Replace("https://github.com/", string.Empty).TrimEnd('/');
-    }
-}


### PR DESCRIPTION
Use fix titles for repo and project URL instead of showing the URL itself. This solves issues when the URL is longer than the available space, e.g. here:

![image](https://user-images.githubusercontent.com/2190718/102719863-c7680780-42f0-11eb-9522-c561d8e79f84.png)

After this PR:

![image](https://user-images.githubusercontent.com/2190718/102720086-604b5280-42f2-11eb-8a42-dce29cc6292b.png)
