### PR TITLE
GH-1294: Leverage AnalyzedPackageVersion and AnalyzedPackageIsPrerelease from addin metadata

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -162,8 +162,7 @@ Task("GetExtensionPackages")
         context.DownloadPackages(extensionDir,
             extensionSpecs
                 .Where(x => !string.IsNullOrEmpty(x.NuGet))
-                .Select(x => x.NuGet)
-                .ToArray());
+                .ToDictionary(e => e.NuGet, e => e.AnalyzedPackageVersion));
 
         context.CalcSupportedCakeVersions(extensionDir,
             extensionSpecs

--- a/config.wyam
+++ b/config.wyam
@@ -20,12 +20,6 @@ Pipelines.InsertBefore(Docs.Code, "Extensions",
     ReadFiles("../extensions/*.yml"),
     Yaml(),
     Meta(
-        "IsPrerelease",
-        FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.isprerelease").Exists
-            ? bool.Parse(FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.isprerelease").ReadAllText())
-            : false
-    ),
-    Meta(
         "SupportedCakeVersions",
         FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.supportedcakeversions").Exists
             ? FileSystem.GetInputFile($"../release/extensions/{@doc.String("NuGet")}.supportedcakeversions").ReadAllText()

--- a/input/_UsageAddin.cshtml
+++ b/input/_UsageAddin.cshtml
@@ -3,7 +3,7 @@
 @{
     string nuget = Model.String("NuGet");
     string version = Model.String("AnalyzedPackageVersion");
-    bool isPrerelease = Model.Bool("isPrerelease");
+    bool isPrerelease = Model.Bool("AnalyzedPackageIsPrerelease");
     string preReleaseQueryParam = isPrerelease ? "&prerelease" : string.Empty;
 }
 


### PR DESCRIPTION
- Download addin nuget packages using `AnalyzedPackageVersion` (removed logic of downloading latest available)
- Use `AnalyzedPackageIsPrerelease` to determine if package is prerelease (for [info alert and preprocessor directive](https://github.com/cake-build/website/pull/1266))

---

Closes #1294
