### PR TITLE
GH-580: Display Target Framework Monikers (TFMs) that addins target

### DIFF
--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -18,6 +18,7 @@
     string publishDate = Model.String("AnalyzedPackagePublishDate");
     string supportedCakeVersions = Model.String("SupportedCakeVersions");
     string categories = (String.Join(" ", Model.List<string>("Categories").Select(x => $"<span class=\"badge badge-secondary\">{x}</span>")));
+    var targetFrameworks = Model.List<string>("TargetFrameworks")?.Where(tfm => !string.IsNullOrWhiteSpace(tfm)).ToList() ?? new List<string>();
     var assemblies = Model.List<string>("Assemblies");
 }
 
@@ -124,6 +125,17 @@
                 </li>
             }
         </ul>
+
+        @if (targetFrameworks.Count > 0)
+        {
+            <h2 class="no-anchor">Target Frameworks</h2>
+            <p>
+                @foreach (var tfm in targetFrameworks)
+                {
+                    <span class="badge badge-secondary">@tfm</span>
+                }
+            </p>
+        }
 
         <h2 class="no-anchor">Authors</h2>
         <p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/177608/102729761-6ba97880-4308-11eb-9559-2253f6681e08.png)

The TFMs are shown as badges similar to the categories, whenever one or more TFM is present in the addin metadata. If no TFM is present, the "Target Frameworks" section (including the header) is not displayed.

There are a few addins that either do not contain a TFM, or contain the word `any`. ~I'll open a separate issue~ I opened issues https://github.com/cake-contrib/Cake.AddinDiscoverer/issues/167 and https://github.com/cake-contrib/Cake.AddinDiscoverer/issues/168 in the Addin Discoverer repo to discuss these as I think it would better handled there (i.e. fix the data) rather than adding special handling in the website.

---

Here is the combination of the different TFMs of all addins as of this writing:

| Target Frameworks | Addin Count | Sample Addin |
|:---:|:---:|:---:|
| `netcoreapp2.0`, `netcoreapp2.1`, `netcoreapp3.0`, `netstandard2.0` | 1 | [Cake.Issues.Reporting.Generic](https://github.com/cake-build/website/blob/master/extensions/Cake.Issues.Reporting.Generic.yml) |
| `netstandard1.3`, `netstandard1.6` | 1 | [MagicChunks](https://github.com/cake-build/website/blob/master/extensions/MagicChunks.yml) |
| `net45`, `net46`, `netstandard1.6` | 1 | [Cake.DependencyCheck](https://github.com/cake-build/website/blob/master/extensions/Cake.DependencyCheck.yml) |
| `net461`, `netstandard2.0` | 25 | [Cake.7zip](https://github.com/cake-build/website/blob/master/extensions/Cake.7zip.yml) |
| `net461`, `netstandard2.1` | 1 | [Cake.SSRS](https://github.com/cake-build/website/blob/master/extensions/Cake.SSRS.yml) |
| `net45`, `netstandard1.6` | 2 | [Cake.NSwag.Console](https://github.com/cake-build/website/blob/master/extensions/Cake.NSwag.Console.yml) |
| `net46`, `netstandard1.6` | 1 | [Cake.HandlebarsDotNet](https://github.com/cake-build/website/blob/master/extensions/Cake.HandlebarsDotNet.yml) |
| `net46`, `netstandard2.0` | 29 | [Cake.AliaSql](https://github.com/cake-build/website/blob/master/extensions/Cake.AliaSql.yml) |
| `net48`, `netstandard2.0` | 1 | [Cake.CoverageComparer](https://github.com/cake-build/website/blob/master/extensions/Cake.CoverageComparer.yml) |
| `netstandard1.6` | 1 | [Cake.Microsoft.Extensions.Configuration](https://github.com/cake-build/website/blob/master/extensions/Cake.Microsoft.Extensions.Configuration.yml) |
| `netstandard2.0` | 144 | [Cake.Android.Adb](https://github.com/cake-build/website/blob/master/extensions/Cake.Android.Adb.yml) |
| `netstandard2.1` | 1 | [Cake.NScan](https://github.com/cake-build/website/blob/master/extensions/Cake.NScan.yml) |
| `net461` | 16 | [Cake.Deploy.Azure.Authentication](https://github.com/cake-build/website/blob/master/extensions/Cake.Deploy.Azure.Authentication.yml) |
| `net45` | 26 | [Cake.ActiveDirectory](https://github.com/cake-build/website/blob/master/extensions/Cake.ActiveDirectory.yml) |
| `net46` | 12 | [Cake.AWS.ElasticBeanstalk](https://github.com/cake-build/website/blob/master/extensions/Cake.Aws.ElasticBeanstalk.yml) |
| `any` | 1 | [Cake.XmlDoc.Checker](https://github.com/cake-build/website/blob/master/extensions/Cake.XmlDoc.Checker.yml) |
| _(empty)_ | 9 | [Cake.Deploy.Azure.ResourceManager](https://github.com/cake-build/website/blob/master/extensions/Cake.Deploy.Azure.ResourceManager.yml) |
|  |  |  |
| **Total** | **272** | |

---

Fixes #580
