### PR TITLE
Only show arguments in examples

### DIFF
--- a/input/docs/running-builds/configuration/set-configuration-values.md
+++ b/input/docs/running-builds/configuration/set-configuration-values.md
@@ -46,82 +46,8 @@ The configuration file should be located in the same directory as your Cake scri
 
 Finally, you can specify an input parameter directly to Cake, in the following format:
 
-<ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool1">Cake .NET Tool</a></li>
-    <li><a data-toggle="tab" href="#frosting1">Cake Frosting</a></li>
-    <li><a data-toggle="tab" href="#netfx1">Cake runner for .NET Framework</a></li>
-    <li><a data-toggle="tab" href="#core1">Cake runner for .NET Core</a></li>
-</ul>
-
-<div class="tab-content">
-    <div id="tool1" class="tab-pane fade in active">
-        <p>
-            <code class="language-powershell hljs">
-                dotnet cake --nuget_source=http://mycustomurl
-            </code>
-        </p>
-    </div>
-    <div id="frosting1" class="tab-pane fade">
-        <p>
-            <code class="language-powershell hljs">
-                ./build.ps1 --nuget_source=http://mycustomurl
-            </code>
-        </p>
-    </div>
-    <div id="netfx1" class="tab-pane fade">
-        <p>
-            <code class="language-powershell hljs">
-                cake.exe --nuget_source=http://mycustomurl
-            </code>
-        </p>
-    </div>
-    <div id="core1" class="tab-pane fade">
-        <p>
-            <code class="language-powershell hljs">
-                cake.exe --nuget_source=http://mycustomurl
-            </code>
-        </p>
-    </div>
-</div>
+```powershell
+--nuget_source=http://mycustomurl
+```
 
 Passing a configuration value directly to Cake will override the same configuration value stored within an environment variable and also any stored in a local configuration file.
-
-When configuring NuGet sources in both `cake.config`, and via the command line, multiple sources can be supplied by joining them with a semicolon:
-
-<ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool2">Cake .NET Tool</a></li>
-    <li><a data-toggle="tab" href="#frosting2">Cake Frosting</a></li>
-    <li><a data-toggle="tab" href="#netfx2">Cake runner for .NET Framework</a></li>
-    <li><a data-toggle="tab" href="#core2">Cake runner for .NET Core</a></li>
-</ul>
-
-<div class="tab-content">
-    <div id="tool2" class="tab-pane fade in active">
-        <p>
-            <code class="language-powershell hljs">
-                dotnet cake --nuget_source=http://mycustomurl;http://myothercustomurl
-            </code>
-        </p>
-    </div>
-    <div id="frosting2" class="tab-pane fade">
-        <p>
-            <code class="language-powershell hljs">
-                ./build.ps1 --nuget_source=http://mycustomurl;http://myothercustomurl
-            </code>
-        </p>
-    </div>
-    <div id="netfx2" class="tab-pane fade">
-        <p>
-            <code class="language-powershell hljs">
-                cake.exe --nuget_source=http://mycustomurl;http://myothercustomurl
-            </code>
-        </p>
-    </div>
-    <div id="core2" class="tab-pane fade">
-        <p>
-            <code class="language-powershell hljs">
-                cake.exe --nuget_source=http://mycustomurl;http://myothercustomurl
-            </code>
-        </p>
-    </div>
-</div>

--- a/input/docs/writing-builds/args-and-environment-vars.md
+++ b/input/docs/writing-builds/args-and-environment-vars.md
@@ -8,55 +8,17 @@ This page explains how settings can be passed to Cake file.
 
 # Passing And Reading Arguments
 
-Call the [Argument alias](/dsl/arguments/) in your Cake file to read arguments from the command line.
-
-## Example
-
-Build script:
+Call the [Argument alias](/dsl/arguments/) in your Cake file to read arguments from the command line:
 
 ```csharp
 Argument<bool>("myargument", false);
 ```
 
-Execution:
+The argument can be passed while running Cake:
 
-<ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool1">Cake .NET Tool</a></li>
-    <li><a data-toggle="tab" href="#frosting1">Cake Frosting</a></li>
-    <li><a data-toggle="tab" href="#netfx1">Cake runner for .NET Framework</a></li>
-    <li><a data-toggle="tab" href="#core1">Cake runner for .NET Core</a></li>
-</ul>
-
-<div class="tab-content">
-    <div id="tool1" class="tab-pane fade in active">
-        <p>
-            <code class="language-powershell hljs">
-                dotnet cake --myargument=true
-            </code>
-        </p>
-    </div>
-    <div id="frosting1" class="tab-pane fade">
-        <p>
-            <code class="language-powershell hljs">
-                dotnet Cake.Frosting.dll --myargument=true
-            </code>
-        </p>
-    </div>
-    <div id="netfx1" class="tab-pane fade">
-        <p>
-            <code class="language-powershell hljs">
-                Cake.exe --myargument=true
-            </code>
-        </p>
-    </div>
-    <div id="core1" class="tab-pane fade">
-        <p>
-            <code class="language-powershell hljs">
-                Cake.exe --myargument=true
-            </code>
-        </p>
-    </div>
-</div>
+```powershell
+--myargument=true
+```
 
 :::{.alert .alert-info}
 The conversion uses [type converters](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.typeconverter) under the hood to convert the string value to the desired type.

--- a/input/docs/writing-builds/running-targets.md
+++ b/input/docs/writing-builds/running-targets.md
@@ -36,125 +36,16 @@ Task("Publish")
 RunTarget(target);
 ```
 
-With this Cake script, you can run a specific target by passing the `--target` argument to Cake. Thus, we can run the `"Publish"` target by calling:
+With this Cake script, you can run a specific target by passing the `--target` argument to Cake.
+Thus, we can run the `"Publish"` target by calling Cake with the following argument:
 
-<ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool1">Cake .NET Tool</a></li>
-    <li><a data-toggle="tab" href="#frosting1">Cake Frosting</a></li>
-    <li><a data-toggle="tab" href="#netfx1">Cake runner for .NET Framework</a></li>
-    <li><a data-toggle="tab" href="#core1">Cake runner for .NET Core</a></li>
-</ul>
-
-<div class="tab-content">
-    <div id="tool1" class="tab-pane fade in active">
-        <p>
-            <code class="language-powershell hljs">
-                dotnet cake --target=Publish
-            </code>
-        </p>
-    </div>
-    <div id="frosting1" class="tab-pane fade">
-        <p>
-            On Windows:<br/>
-            <code class="language-powershell hljs">
-                ./build.ps1 --target=Publish
-            </code>
-        </p>
-        <p>
-            On macOS & Linux:<br/>
-            <code class="language-bash hljs">
-                build.sh --target=Publish
-            </code>
-        </p>
-    </div>
-    <div id="netfx1" class="tab-pane fade">
-        <p>
-            On Windows:<br/>
-            <code class="language-powershell hljs">
-                ./build.ps1 --target=Publish
-            </code>
-        </p>
-        <p>
-            On macOS & Linux using Mono:<br/>
-            <code class="language-bash hljs">
-                build.sh --target=Publish
-            </code>
-        </p>
-    </div>
-    <div id="core1" class="tab-pane fade">
-        <p>
-            On Windows:<br/>
-            <code class="language-powershell hljs">
-                ./build.ps1 --target=Publish
-            </code>
-        </p>
-        <p>
-            On macOS & Linux:<br/>
-            <code class="language-bash hljs">
-                build.sh --target=Publish
-            </code>
-        </p>
-    </div>
-</div>
+```powershell
+--target=Publish
+```
 
 The `--exclusive` parameter causes `RunTarget` to run only the specified target and no dependencies.
-This command runs the `Publish` target without running the `Build` target:
+The following arguments will run the `Publish` target without running the `Build` target:
 
-<ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#tool2">Cake .NET Tool</a></li>
-    <li><a data-toggle="tab" href="#frosting2">Cake Frosting</a></li>
-    <li><a data-toggle="tab" href="#netfx2">Cake runner for .NET Framework</a></li>
-    <li><a data-toggle="tab" href="#core2">Cake runner for .NET Core</a></li>
-</ul>
-
-<div class="tab-content">
-    <div id="tool2" class="tab-pane fade in active">
-        <p>
-            <code class="language-powershell hljs">
-                dotnet cake --target=Publish --exclusive
-            </code>
-        </p>
-    </div>
-    <div id="frosting2" class="tab-pane fade">
-        <p>
-            On Windows:<br/>
-            <code class="language-powershell hljs">
-                ./build.ps1 --target=Publish --exclusive
-            </code>
-        </p>
-        <p>
-            On macOS & Linux:<br/>
-            <code class="language-bash hljs">
-                build.sh --target=Publish --exclusive
-            </code>
-        </p>
-    </div>
-    <div id="netfx2" class="tab-pane fade">
-        <p>
-            On Windows:<br/>
-            <code class="language-powershell hljs">
-                ./build.ps1 --target=Publish --exclusive
-            </code>
-        </p>
-        <p>
-            On macOS & Linux using Mono:<br/>
-            <code class="language-powershell hljs">
-                ./build.ps1 --target=Publish --exclusive
-            </code>
-        </p>
-    </div>
-    <div id="core2" class="tab-pane fade">
-        <p>
-            On Windows:<br/>
-            <code class="language-powershell hljs">
-                ./build.ps1 --target=Publish --exclusive
-            </code>
-        </p>
-        <p>
-            On macOS & Linux:<br/>
-            <code class="language-bash hljs">
-                build.sh --target=Publish --exclusive
-            </code>
-        </p>
-    </div>
-</div>
+```powershell
+--target=Publish --exclusive
+```


### PR DESCRIPTION
We currently have different documentation how to run the different runners.
- http://cakebuild.net/docs/writing-builds/running-targets#passing-a-target-to-the-script uses `dotnet cake` for tool and bootstrapper for other runners
- http://cakebuild.net/docs/writing-builds/args-and-environment-vars#passing-and-reading-arguments is without bootstrapper for all runners
- https://cakebuild.net/docs/running-builds/configuration/set-configuration-values uses bootstrapper for Cake Frosting, but not for other runners.

This PR makes examples consistent by removing the Cake invocation part and only showing the arguments. Instead of showing call with bootstrapper (which is still different for every OS this makes documentation much more focused on the specific topic which we want to explain. Different ways how to run Cake, with or without bootstrapper and for every different runner is available on documentation page for every runner (e.g. https://cakebuild.net/docs/running-builds/runners/dotnet-tool).

Also removes the example in Set Configuration Values where we show how to pass multiple NuGet sources on command line, since this is something specific for this configuration value and not specific to setting configuratoin values on command line and already documented at https://cakebuild.net/docs/running-builds/configuration/default-configuration-values#nuget-download-url.