### PR TITLE
GH-1427: Add ability to sort extensions by name & publish date

### DIFF
--- a/input/_ExtensionsList.cshtml
+++ b/input/_ExtensionsList.cshtml
@@ -27,7 +27,7 @@
         string publishDate = extension.String("AnalyzedPackagePublishDate");
         string categories = (String.Join(", ", extension.List<string>("Categories")));
 
-        <article class="extension row" data-name="@name" data-categories="@categories">
+        <article class="extension row" data-name="@name" data-analyzedpackagepublishdate="@publishDate" data-categories="@categories">
             <div class="col-sm-1 hidden-xs hidden-sm col-package-icon">
                 <i class="fa fa-puzzle-piece fa-4x"></i>
             </div>

--- a/input/_ExtensionsPage.cshtml
+++ b/input/_ExtensionsPage.cshtml
@@ -22,6 +22,14 @@
 
     <input id="search" type="text" class="search" aria-label="Enter extensions to search" placeholder="Search for extensions..." autocomplete="off" value>
 
+    <div class="form-group row">
+        <label class="col-sm-1 col-form-label">Sort by</label>
+        <div class="col-sm-10">
+            <button class="sort btn btn-default asc" data-sort="name">Name</button>
+            <button class="sort btn btn-default" data-sort="analyzedpackagepublishdate" data-default-order="desc">Publish Date</button>
+        </div>
+    </div>
+
     <div class="row no-margin">
         <div id="result-count" class="col-md-10 no-padding">
             @extensions.Count() extensions found
@@ -36,6 +44,7 @@
     var options = {
       valueNames: [
         { data: ['name'] },
+        { data: ['analyzedpackagepublishdate'] },
         { data: ['categories'] }
       ]
     };

--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -191,3 +191,14 @@ ul.share-buttons img{
   hyphens: auto;
 }
 
+// Sort buttons
+
+.sort.asc::after {
+  content: "\002B06";
+  padding-left: 3px;
+}
+
+.sort.desc::after {
+  content: "\002B07";
+  padding-left: 3px;
+}


### PR DESCRIPTION
![2020-12-28_12-33-50 (1)](https://user-images.githubusercontent.com/177608/103229814-39040f00-490a-11eb-859b-212165bce8ea.gif)

---

Closes #1427