### PR TITLE
Add a panel for sorting and filtering of extensions

### DIFF
--- a/input/_ExtensionsPage.cshtml
+++ b/input/_ExtensionsPage.cshtml
@@ -22,17 +22,25 @@
 
     <input id="search" type="text" class="search" aria-label="Enter extensions to search" placeholder="Search for extensions..." autocomplete="off" value>
 
-    <div class="form-group row">
-        <label class="col-sm-1 col-form-label">Sort by</label>
-        <div class="col-sm-10">
-            <button class="sort btn btn-default asc" data-sort="name">Name</button>
-            <button class="sort btn btn-default" data-sort="analyzedpackagepublishdate" data-default-order="desc">Publish Date</button>
-        </div>
-    </div>
-
     <div class="row no-margin">
         <div id="result-count" class="col-md-10 no-padding">
             @extensions.Count() extensions found
+        </div>
+        <div class="col-md-2 col-xs-3 col-sm-1 text-right no-padding">
+            <button class="btn-filter" data-toggle="collapse" data-target="#extension-filter" aria-expanded="false" aria-controls="extension-filter">
+                <i class="fa fa-filter"></i>
+                Sort &amp; Filter
+            </button>
+        </div>
+    </div>
+
+    <div class="panel panel-default collapse" id="extension-filter">
+        <div class="row panel-body">
+            <div class="col-md-2">
+                <div>Sort by</div>
+                <button class="sort btn btn-default asc" data-sort="name">Name</button>
+                <button class="sort btn btn-default" data-sort="analyzedpackagepublishdate" data-default-order="desc">Publish Date</button>
+            </div>
         </div>
     </div>
 

--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -128,6 +128,31 @@ ul.share-buttons img{
   margin-bottom: 15px;
 }
 
+.btn-filter {
+  background-color: transparent;
+  border: none;
+}
+
+.sort {
+  width: 100%;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.sort.asc::after {
+  content: "\002B06";
+  padding-left: 3px;
+}
+
+.sort.desc::after {
+  content: "\002B07";
+  padding-left: 3px;
+}
+
+#extension-filter {
+  margin-top: 15px;
+}
+
 .list-extensions .extension {
   padding-top: 15px;
   padding-bottom: 15px;
@@ -189,16 +214,4 @@ ul.share-buttons img{
   -moz-hyphens: auto;
   -ms-hyphens: auto;
   hyphens: auto;
-}
-
-// Sort buttons
-
-.sort.asc::after {
-  content: "\002B06";
-  padding-left: 3px;
-}
-
-.sort.desc::after {
-  content: "\002B07";
-  padding-left: 3px;
 }


### PR DESCRIPTION
Implements a panel which can be toggled for sort and filter functionality in extension page:

![image](https://user-images.githubusercontent.com/2190718/103245626-0b968000-4961-11eb-9ef1-4cf1ad0479c2.png)

When toggled:

![image](https://user-images.githubusercontent.com/2190718/103245659-210baa00-4961-11eb-8df1-c70a7ebc8dda.png)
