### PR TITLE
GH-1410: Document NO_COLOR environment variable

### DIFF
--- a/input/docs/running-builds/configuration/default-configuration-values.md
+++ b/input/docs/running-builds/configuration/default-configuration-values.md
@@ -343,6 +343,28 @@ Tools=./tools</code></pre>
     </div>
 </div>
 
+# Disable Colors in output text
+
+:::{.alert .alert-info}
+Available since Cake `1.1.0`.
+:::
+
+By default, Cake outputs colored text when it detects it is running on an environment that supports ANSI escape codes.
+
+To disable output of colored text, set an environment variable with the name [`NO_COLOR`](https://no-color.org) with any value.
+
+<ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" href="#env10">Environment variable name</a></li>
+</ul>
+
+<div class="tab-content">
+    <div id="env10" class="tab-pane fade in active">
+        <p>
+            <pre><code class="language-sh hljs">NO_COLOR</code></pre>
+        </p>
+    </div>
+</div>
+
 [Cake .NET Tool]: /docs/running-builds/runners/dotnet-tool
 [Cake runner for .NET Framework]: /docs/running-builds/runners/cake-runner-for-dotnet-framework
 [Cake runner for .NET Core]: /docs/running-builds/runners/cake-runner-for-dotnet-core


### PR DESCRIPTION
Edit: The `NO_COLOR` didn't make it to the v1.0.0 release and was merged into `develop` - to be released as `v1.x.x`
I've updated the PR to say "_Available since Cake `1.1.0`_" as an initial guess and can update it again as needed. The screenshot below is stale.

---

![image](https://user-images.githubusercontent.com/177608/103247289-c3fdfd00-493c-11eb-86c0-0af6c2a94639.png)

---

Closes #1410