### PR TITLE
Show latest Cake version on home page

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,6 +6,7 @@
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.32.0"
 
 #load "nuget.cake"
+#load "github.cake"
 
 using Octokit;
 
@@ -171,8 +172,10 @@ Task("GetExtensionPackages")
 
 Task("Build")
     .IsDependentOn("GetArtifacts")
-    .Does(() =>
+    .Does(context =>
     {
+        var releaseInfo = context.GetCakeGitHubReleaseInfo(releaseDir);
+
         Wyam(new WyamSettings
         {
             Recipe = "Docs",
@@ -180,7 +183,9 @@ Task("Build")
             UpdatePackages = true,
             Settings = new Dictionary<string, object>
             {
-                { "AssemblyFiles",  extensionSpecs.Where(x => x.Assemblies != null).SelectMany(x => x.Assemblies).Select(x => "../release/extensions" + x) }
+                { "AssemblyFiles",  extensionSpecs.Where(x => x.Assemblies != null).SelectMany(x => x.Assemblies).Select(x => "../release/extensions" + x) },
+                { "CakeLatestReleaseName", releaseInfo.LatestReleaseName },
+                { "CakeLatestReleaseUrl", releaseInfo.LatestReleaseUrl },
             }
         });
     });
@@ -188,8 +193,10 @@ Task("Build")
 // Does not download artifacts (run Build or GetArtifacts target first)
 Task("Preview")
     .IsDependentOn("GetExtensionSpecs")
-    .Does(() =>
+    .Does(context =>
     {
+        var releaseInfo = context.GetCakeGitHubReleaseInfo(releaseDir);
+
         Wyam(new WyamSettings
         {
             Recipe = "Docs",
@@ -199,7 +206,9 @@ Task("Preview")
             Watch = true,
             Settings = new Dictionary<string, object>
             {
-                { "AssemblyFiles",  extensionSpecs.Where(x => x.Assemblies != null).SelectMany(x => x.Assemblies).Select(x => "../release/extensions" + x) }
+                { "AssemblyFiles",  extensionSpecs.Where(x => x.Assemblies != null).SelectMany(x => x.Assemblies).Select(x => "../release/extensions" + x) },
+                { "CakeLatestReleaseName", releaseInfo.LatestReleaseName },
+                { "CakeLatestReleaseUrl", releaseInfo.LatestReleaseUrl },
             }
         });
     });

--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,6 @@
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=2.2.9"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Yaml&version=3.1.1"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=YamlDotNet&version=6.1.2"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.32.0"
 
 #load "nuget.cake"
 #load "github.cake"
@@ -107,19 +106,11 @@ Task("CleanSource")
 
 Task("GetSource")
     .IsDependentOn("CleanSource")
-    .Does(() =>
+    .Does(context =>
     {
-        GitHubClient github = new GitHubClient(new ProductHeaderValue("CakeDocs"));
+        var releaseInfo = context.GetCakeGitHubReleaseInfo(releaseDir);
 
-        if (!string.IsNullOrEmpty(accessToken))
-        {
-            github.Credentials = new Credentials(accessToken);
-        }
-
-        // The GitHub releases API returns Not Found if all are pre-release, so need workaround below
-        //Release release = github.Repository.Release.GetLatest("cake-build", "cake").Result;
-        Release release = github.Repository.Release.GetAll("cake-build", "cake").Result.First( r =>r.PublishedAt.HasValue);
-        FilePath releaseZip = DownloadFile(release.ZipballUrl);
+        FilePath releaseZip = DownloadFile(releaseInfo.LatestReleaseZipUrl);
         Unzip(releaseZip, releaseDir);
 
         // Need to rename the container directory in the zip file to something consistent

--- a/build.cake
+++ b/build.cake
@@ -22,7 +22,6 @@ var target = Argument("target", "Default");
 // Define variables
 var isRunningOnAppVeyor  = AppVeyor.IsRunningOnAppVeyor;
 var isPullRequest        = AppVeyor.Environment.PullRequest.IsPullRequest;
-var accessToken          = EnvironmentVariable("git_access_token");
 var deployRemote         = EnvironmentVariable("git_deploy_remote");
 var zipFileName          = "output.zip";
 var deployCakeFileName   = "deploy.cake";

--- a/github.cake
+++ b/github.cake
@@ -1,4 +1,4 @@
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.32.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.48.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=NuGet.Versioning&version=5.7.0"
 
 using Octokit;
@@ -51,6 +51,7 @@ public static CakeGitHubReleaseInfo GetCakeGitHubReleaseInfo(this ICakeContext c
     {
         LatestReleaseName = latestCakeRelease.Name,
         LatestReleaseUrl = latestCakeRelease.HtmlUrl,
+        LatestReleaseZipUrl = latestCakeRelease.ZipballUrl,
     };
 
     LogGitHubReleaseInfo(context, _cakeGitHubReleaseInfo);
@@ -65,10 +66,12 @@ private static void LogGitHubReleaseInfo(ICakeContext context, CakeGitHubRelease
 {
     context.Information("Cake Latest Release Name: {0}", releaseInfo.LatestReleaseName);
     context.Information("Cake Latest Release Url: {0}", releaseInfo.LatestReleaseUrl);
+    context.Information("Cake Latest Release Zip Url: {0}", releaseInfo.LatestReleaseZipUrl);
 }
 
 public class CakeGitHubReleaseInfo
 {
     public string LatestReleaseName { get; set; }
     public string LatestReleaseUrl { get; set; }
+    public string LatestReleaseZipUrl { get; set; }
 }

--- a/github.cake
+++ b/github.cake
@@ -1,0 +1,74 @@
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.32.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=NuGet.Versioning&version=5.7.0"
+
+using Octokit;
+using NuGet.Versioning;
+
+static CakeGitHubReleaseInfo _cakeGitHubReleaseInfo;
+
+public static CakeGitHubReleaseInfo GetCakeGitHubReleaseInfo(this ICakeContext context, DirectoryPath releaseDir)
+{
+    if (!(_cakeGitHubReleaseInfo is null))
+    {
+        return _cakeGitHubReleaseInfo;
+    }
+
+    // We cache the latest Cake release information in a file to speed up local development and also
+    // to decrease the chance of getting rate limited by GitHub when running unauthenticated
+    var cachedGitHubDir = context.MakeAbsolute(releaseDir.Combine("cake-github"));
+    var cachedReleaseInfoFile = cachedGitHubDir.CombineWithFilePath($"{nameof(CakeGitHubReleaseInfo)}.yml");
+    if (context.FileExists(cachedReleaseInfoFile))
+    {
+        context.Verbose("Retrieving Cake release information from cached file {0}...", cachedReleaseInfoFile);
+
+        _cakeGitHubReleaseInfo = context.DeserializeYamlFromFile<CakeGitHubReleaseInfo>(cachedReleaseInfoFile);
+        LogGitHubReleaseInfo(context, _cakeGitHubReleaseInfo);
+
+        return _cakeGitHubReleaseInfo;
+    }
+
+    context.Information("Retrieving Cake release information from GitHub...");
+
+    var client = new GitHubClient(new ProductHeaderValue("cake-build-website"));
+
+    var gitHubAccessToken =  context.EnvironmentVariable("git_access_token");
+    if (!string.IsNullOrWhiteSpace(gitHubAccessToken))
+    {
+        client.Credentials = new Credentials(gitHubAccessToken);
+    }
+
+    var allCakeReleases = client.Repository.Release.GetAll("cake-build", "cake")
+        .GetAwaiter()
+        .GetResult()
+        .Where(r => !r.Draft && r.PublishedAt.HasValue && r.Name.StartsWith("v", StringComparison.Ordinal))
+        .OrderByDescending(r => new NuGetVersion(r.Name.Substring(1)))
+        .ToList();
+
+    var latestCakeRelease = allCakeReleases
+        .First();
+
+    _cakeGitHubReleaseInfo = new CakeGitHubReleaseInfo
+    {
+        LatestReleaseName = latestCakeRelease.Name,
+        LatestReleaseUrl = latestCakeRelease.HtmlUrl,
+    };
+
+    LogGitHubReleaseInfo(context, _cakeGitHubReleaseInfo);
+
+    context.EnsureDirectoryExists(cachedReleaseInfoFile.GetDirectory());
+    context.SerializeYamlToFile<CakeGitHubReleaseInfo>(cachedReleaseInfoFile, _cakeGitHubReleaseInfo);
+
+    return _cakeGitHubReleaseInfo;
+}
+
+private static void LogGitHubReleaseInfo(ICakeContext context, CakeGitHubReleaseInfo releaseInfo)
+{
+    context.Information("Cake Latest Release Name: {0}", releaseInfo.LatestReleaseName);
+    context.Information("Cake Latest Release Url: {0}", releaseInfo.LatestReleaseUrl);
+}
+
+public class CakeGitHubReleaseInfo
+{
+    public string LatestReleaseName { get; set; }
+    public string LatestReleaseUrl { get; set; }
+}

--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -215,3 +215,16 @@ ul.share-buttons img{
   -ms-hyphens: auto;
   hyphens: auto;
 }
+
+// Latest Cake version alert
+
+.alert-latest-version {
+    padding: 5px;
+    text-align: center;
+    background-color: #ceb55a;
+}
+
+.alert-latest-version a {
+    font-weight: bold;
+    color: #333333;
+}

--- a/input/blog/2020-12-20-cake-v1.0.0-rc0002-released.md
+++ b/input/blog/2020-12-20-cake-v1.0.0-rc0002-released.md
@@ -2,6 +2,7 @@
 title: Cake v1.0.0-rc0002 released
 category: Release Notes
 author: devlead
+releaseName: v1.0.0-rc0002
 ---
 
 Version 1.0.0-rc0002 of Cake has been released.

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -3,6 +3,28 @@ NoSidebar: true
 NoContainer: true
 NoGutter: true
 ---
+@{
+    // Latest Cake release name from GitHub e.g. v1.0.0-rc0002
+    var latestReleaseName = Model.String("CakeLatestReleaseName") ?? "x.y.z";
+
+    // All documents in the "Release Notes" category
+    var releaseBlogPosts = Documents
+        .Where(d => "Release Notes".Equals(d.String("category"), StringComparison.Ordinal));
+
+    // Attempt to locate a corresponding blog post for the latest Cake release
+    // NB: Blog posts need to have `releaseName` in the front matter matching the GitHub release name
+    var latestReleaseBlogPost = releaseBlogPosts
+        .Where(p => latestReleaseName.Equals(p.String("releaseName"), StringComparison.Ordinal))
+        .FirstOrDefault();
+
+    // Use link to blog post if found, otherwise fallback to link to GitHub release
+    var latestReleaseUrl = latestReleaseBlogPost is null
+        ? Model.String("CakeLatestReleaseUrl") ?? "#"
+        : Context.GetLink(latestReleaseBlogPost);
+}
+<div class="alert-latest-version">
+    <a href="@latestReleaseUrl">Cake @latestReleaseName is now available</a>
+</div>
 <div class="jumbotron">
     <div class="container">
         <div class="row">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/177608/103385289-2a675480-4ad0-11eb-9e2b-c6c039158a0e.png)

Given that the build pipeline already uses the GitHub API to get the latest release (and download the source) and also the fact that we expect to use the latest version number in multiple places (e.g. https://github.com/cake-build/website/issues/1139, https://github.com/cake-build/website/issues/1428) I decided on the following approach:

- Use the GitHub API to get latest release from cake-build/cake repo via the Cake build
- Add it to the global Wyam metadata via settings
- Search for a blog post with a matching `releaseName` on the front matter (1)
    - Link to the blog post if found, otherwise link to the GitHub release

(1) This means that moving forward, posts of release announcements should include a metadata `releaseName` in the front matter with the same name of the GitHub release (e.g. v1.0.0-rc0002) for the alert on the home page to automatically link to the blog post. In case there is no blog post, the alert will link to the release notes on GitHub.

---

Closes https://github.com/cake-build/website/issues/1139
