### PR TITLE
Automatically use latest version in getting started guide

### DIFF
--- a/input/docs/getting-started/setting-up-a-new-project.md
+++ b/input/docs/getting-started/setting-up-a-new-project.md
@@ -21,10 +21,10 @@ Make sure to have a tool manifest available in your repository or create one usi
 dotnet new tool-manifest
 ```
 
-Install Cake as a local tool using the `dotnet tool` command (replace `x.y.z` with the version of Cake you want to use, e.g. 0.38.5):
+Install Cake as a local tool using the `dotnet tool` command (you can replace `<?! Meta CakeLatestReleaseName /?>` with a different version of Cake you want to use):
 
 ```powershell
-dotnet tool install Cake.Tool --version x.y.z
+dotnet tool install Cake.Tool --version <?! Meta CakeLatestReleaseName /?>
 ```
 
 :::{.alert .alert-info}


### PR DESCRIPTION
This PR builds on https://github.com/cake-build/website/pull/1459 which **should be merged first**. The only addition is commit [`f428886`](https://github.com/cake-build/website/commit/f428886e85c628d50f11d07ffd78f693138baee5) which prints the latest Cake version in the Getting Started/Setting Up A New Project.

![image](https://user-images.githubusercontent.com/177608/103391079-f438cd80-4aed-11eb-9924-201c4b644406.png)

---

Closes https://github.com/cake-build/website/issues/1428
