### PR TITLE
Use latest release number without leading v

### DIFF
--- a/github.cake
+++ b/github.cake
@@ -49,7 +49,7 @@ public static CakeGitHubReleaseInfo GetCakeGitHubReleaseInfo(this ICakeContext c
 
     _cakeGitHubReleaseInfo = new CakeGitHubReleaseInfo
     {
-        LatestReleaseName = latestCakeRelease.Name,
+        LatestReleaseName = latestCakeRelease.Name.TrimStart('v'),
         LatestReleaseUrl = latestCakeRelease.HtmlUrl,
         LatestReleaseZipUrl = latestCakeRelease.ZipballUrl,
     };

--- a/input/blog/2020-12-20-cake-v1.0.0-rc0002-released.md
+++ b/input/blog/2020-12-20-cake-v1.0.0-rc0002-released.md
@@ -2,7 +2,7 @@
 title: Cake v1.0.0-rc0002 released
 category: Release Notes
 author: devlead
-releaseName: v1.0.0-rc0002
+releaseName: 1.0.0-rc0002
 ---
 
 Version 1.0.0-rc0002 of Cake has been released.


### PR DESCRIPTION
Use latest release number without leading `v`, since this is the version number used for the packages.