### PR TITLE
Improve addin guidelines

### DIFF
--- a/input/assets/css/bootstrap/variables.less
+++ b/input/assets/css/bootstrap/variables.less
@@ -856,7 +856,7 @@
 //** Blockquote small color
 @blockquote-small-color:      @gray-light;
 //** Blockquote font size
-@blockquote-font-size:        (@font-size-base * 1.25);
+@blockquote-font-size:        @font-size-base;
 //** Blockquote border color
 @blockquote-border-color:     @gray-lighter;
 //** Page header border color

--- a/input/docs/extending/addins/best-practices.md
+++ b/input/docs/extending/addins/best-practices.md
@@ -1,112 +1,177 @@
 Order: 30
+Title: Best practices for writing addins
 Description: Best practices for writing addins
 ---
 
 This page gives some best practices for writing Cake addins.
+Each guideline describes either a good or bad practice.
 
-# Naming convention for addins
+The wording of each guideline indicates how strong the recommendation is:
 
-Addins should be named `Cake.xxx`, where xxx is a meaningful and unique name that describes what the addin does.
-We strongly encourage to be consistent and use the same name for the GitHub repo, the C# solution name,
-the assembly generated from the project and the NuGet package.
-The `Cake.` prefix in the naming convention is particularly important for the NuGet package and the assembly in the package,
-because it's used by the automated [AddinDiscoverer](https://github.com/cake-contrib/Cake.AddinDiscoverer) to identify addins for Cake.
+> **Do** guidelines should nearly always be followed.
+> You need a really unusual case for breaking a _Do_ guideline.
+>
+> **Consider** guidelines should generally be followed.
+> You can deviate from a _Consider_ guideline if you fully understand the meaning behind the guideline and have a good reason to do so.
+>
+> **Avoid** guidelines indicates something you should almost never do.
 
-For example, `Cake.Email` is the name that clearly identifies the addin for Cake that allows emails to be sent from the build script.
-This name is used in the [GitHub repo](https://github.com/cake-contrib/Cake.Email),
-it's the name of the [solution file](https://github.com/cake-contrib/Cake.Email/blob/develop/Source/Cake.Email.sln),
-it's the name of the [project file](https://github.com/cake-contrib/Cake.Email/blob/develop/Source/Cake.Email/Cake.Email.csproj),
-the name of the [generated assembly](https://github.com/cake-contrib/Cake.Email/blob/develop/Source/Cake.Email/Cake.Email.csproj#L10)
-and finally, it's also the name of the [NuGet package](https://www.nuget.org/packages/Cake.Email/).
+# Naming
 
-# Cake version to build addins against
+**_§1.1_** **Do** use `Cake.xxx` as the naming schema for addins, where `xxx` is a meaningful and unique name that describes what the addin does.
 
-To have the best support for different versions of Cake, the addin should currently be built against Cake version 0.33.0,
-or, if a specific newer functionality is required, the lowest version providing the specific functionality.
-Please note  that addins built against newer versions of Cake might not be compatible with previous versions of Cake and vice-versa,
-addins built against older versions might not be compatible with future versions of Cake (this is especially true when a
-future version of Cake introduces breaking changes).
+> **Why?** Following a convention makes it easier for users to find and work with addins.
+> The automated [AddinDiscoverer](https://github.com/cake-contrib/Cake.AddinDiscoverer), which is used for auditing and keeping website up to date, also uses this convention to identify Cake addins.
 
-It is incumbent on addin authors to upgrade their references and publish new version of their NuGet packages when a new
-version of Cake with breaking changes becomes available.
+> **Example:**
+>
+> `Cake.Email` is the name that clearly identifies the addin for Cake that allows to send emails from the build script.
+> This name is used in the [GitHub repo](https://github.com/cake-contrib/Cake.Email),
+> it's the name of the [solution file](https://github.com/cake-contrib/Cake.Email/blob/develop/Source/Cake.Email.sln),
+> it's the name of the [project file](https://github.com/cake-contrib/Cake.Email/blob/develop/Source/Cake.Email/Cake.Email.csproj),
+> the name of the [generated assembly](https://github.com/cake-contrib/Cake.Email/blob/develop/Source/Cake.Email/Cake.Email.csproj#L10)
+> and finally, it's also the name of the [NuGet package](https://www.nuget.org/packages/Cake.Email/).
 
-Cake versions which are API compatible with a specific addin will be shown when the addin is added to the Cake website.
+----------------------------------------------------------------------------------------------------
 
-# Target .NET version for addins
+**_§1.2_** **Do** use the same name for the GitHub repo, the C# solution name, the assembly generated from the project and the NuGet package.
 
-As .NET Framework < 4.7.2 has issues with running .NET Standard assemblies, and Cake itself can run on .NET Framework 4.6.1 it is
-suggested to multi-target addins to `netstandard2.0` and `net461` to have the maximum compatibility.
+> **Why?** Using the same name across different artifacts makes it easier for users and improves results of automated processes.
+
+# References
+
+## Cake reference
+
+**_§2.1_** **Do** reference the lowest version of Cake with API compatibility to the latest version (currently `0.33.0`).
+
+> **Why?** This gives the best support for different versions of Cake.
+> Addins built against newer versions of Cake might not be compatible with previous versions of Cake and vice-versa,
+> addins built against older versions might not be compatible with future versions of Cake (this is especially true when a future version of Cake introduces breaking changes).
+>
+> Cake versions which are API compatible with a specific addin will be shown when the addin is added to the Cake website.
+
+----------------------------------------------------------------------------------------------------
+
+**_§2.2_** **Do** reference a newer version than Cake `0.33.0` if the addin requires a specific functionality.
+
+> **Why?** If a specific feature of Cake is required in an addin the lowest version of Cake which introduces this feature should be referenced
+> to have access to the feature and the best support for different versions of Cake.
+
+----------------------------------------------------------------------------------------------------
+
+**_§2.3_** **Do** update addin to a newer version of Cake if a version of Cake with breaking changes becomes available.
+
+> **Why?** Cake will output a warning that the addin was built against an incompatible version of Cake and the addin might no longer work.
+> It is incumbent on addin authors to upgrade their references and publish new version of their NuGet packages
+
+----------------------------------------------------------------------------------------------------
+
+**_§2.4_** **Avoid** dependencies to `Cake.Core` and `Cake.Common` in the NuGet package.
+
+> **Why?** Those references are being implicitly added by the Cake engine.
+
+<blockquote class="blockquote">
+  <p>
+    <strong>Example:</strong>
+  </p>
+  <ul class="nav nav-tabs">
+      <li class="active"><a data-toggle="tab" href="#dotnet">dotnet CLI / MSBuild</a></li>
+      <li><a data-toggle="tab" href="#nuget">nuget.exe CLI</a></li>
+  </ul>
+
+  <div class="tab-content">
+      <div id="dotnet" class="tab-pane fade in active">
+         <p>
+              References to <code>Cake.Core</code> and <code>Cake.Common</code> need to be marked as private assets in the project file:
+          </p>
+          <p>
+<pre><code class="language-xml hljs">&lt;ItemGroup&gt;
+  &lt;PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" /&gt;
+  &lt;PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" /&gt;
+&lt;/ItemGroup&gt;
+</code></pre>
+          </p>
+      </div>
+      <div id="nuget" class="tab-pane fade">
+          <p>
+              When using a <code>nuspec</code> file omit the references to <code>Cake.Core</code> and <code>Cake.Common</code>
+          </p>
+      </div>
+  </div>
+</blockquote>
+
+## .NET target version
+
+**_§2.4_** **Consider** to multi-target `netstandard2.0` and `net461`.
+
+> **Why?** Since .NET Framework < 4.7.2 has issues with running .NET Standard assemblies, and Cake itself can run on .NET Framework 4.6.1
+> multi-target addins to `netstandard2.0` and `net461` will give the maximum compatibility.
+>
+> Multi-targeting was suggested by Microsoft in [this .NET Conf 2018 talk](https://www.youtube.com/watch?v=hLFyycJVo0I#t=44m48s) and the underlying issues
+> are explained in [this tweet](https://twitter.com/terrajobst/status/1031999730320986112)
 
 :::{.alert .alert-info}
 This replaces the previous suggestion to only target `netstandard2.0` starting with Cake 0.26.0 as since then issues were found with running `netstandard2.0`
 on .NET Framwork < 4.7.2.
 :::
 
-Multi-targeting was suggested by Microsoft in [this .NET Conf 2018 talk](https://www.youtube.com/watch?v=hLFyycJVo0I#t=44m48s) and the underlying issues
-are explained in [this tweet](https://twitter.com/terrajobst/status/1031999730320986112)
+# Package metadata
 
-## Cake.Core / Cake.Common references in addins
+## Icons
 
-Those references are being implicitly added by the Cake engine.
-Thus there is no need to add them as dependencies inside the `nuspec` file.
+**_§3.1_** **Do** define an icon for the NuGet package.
 
-<ul class="nav nav-tabs">
-    <li class="active"><a data-toggle="tab" href="#dotnet">dotnet CLI / MSBuild</a></li>
-    <li><a data-toggle="tab" href="#nuget">nuget.exe CLI</a></li>
-</ul>
+> **Why?** Icons helps the user to identify Cake addins.
 
-<div class="tab-content">
-    <div id="dotnet" class="tab-pane fade in active">
-        <p>
-            References to <code>Cake.Core</code> and <code>Cake.Common</code> need to be marked as private assets in the project file:
-        </p>
-        <p>
-<pre><code class="language-xml hljs">&lt;ItemGroup&gt;
-  &lt;PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" /&gt;
-  &lt;PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" /&gt;
-&lt;/ItemGroup&gt;
-</code></pre>
-        </p>
-    </div>
-    <div id="nuget" class="tab-pane fade">
-        <p>
-            When using a <code>nuspec</code> file omit the references to <code>Cake.Core</code> and <code>Cake.Common</code>
-        </p>
-    </div>
-</div>
+----------------------------------------------------------------------------------------------------
 
-# NuGet package icon for addins
+**_§3.2_** **Consider** using the [Cake Contrib icon](https://github.com/cake-contrib/graphics/blob/master/png/cake-contrib-medium.png).
 
-When an addin is not part of a product, addins should use the [Cake Contrib icon](https://github.com/cake-contrib/graphics/blob/master/png/cake-contrib-medium.png) rather than the Cake icon or any other custom icon.
-Icons should be embedded in the package rather than rely on an external web site which hosts the icon.
+> **Why?** When the addin doesn't have an own product icon, using the [Cake Contrib icon](https://github.com/cake-contrib/graphics/blob/master/png/cake-contrib-medium.png)
+> gives a common branding to Cake addins.
 
-This can be done with the following line in the addins `.csproj`:
+----------------------------------------------------------------------------------------------------
 
-```xml
-<PackageIcon>PackageIcon.png</PackageIcon>
-```
+**_§3.3_** **Avoid** using the Cake icon.
 
-The addins `.csproj` should also contain a reference to the `png` file:
+> **Why?** The Cake icon is reserved for core Cake packages.
 
-```xml
-<ItemGroup>
-    <None Include="..\PackageIcon.png" Pack="true" PackagePath="" />
-</ItemGroup>
-```
+----------------------------------------------------------------------------------------------------
 
-Notice the `Pack` attribute, this is particularly important to ensure the file is embedded in the NuGet package.
+**_§3.4_** **Do** embed the icon in the package.
+
+> **Why?** Using an icon embedded in the package is more reliable then linking to an icon an external web site which hosts the icon.
+
+> **Example:**
+>
+> This can be done with the following line in the addins `.csproj`:
+>
+> ```xml
+> <PackageIcon>PackageIcon.png</PackageIcon>
+> ```
+>
+> The addins `.csproj` should also contain a reference to the `png` file:
+>
+> ```xml
+> <ItemGroup>
+>     <None Include="..\PackageIcon.png" Pack="true" PackagePath="" />
+> </ItemGroup>
+> ```
+>
+> Notice the `Pack` attribute, this is particularly important to ensure the file is embedded in the NuGet package.
 
 :::{.alert .alert-info}
 Until early 2019, the recommendation was to reference the Cake Contrib icon hosted on the rawgit CDN but rawgit announced that it would shutdown in October 2019 therefore the recommendation changed to reference the Cake Contrib icon hosted on the jsDelivr CDN.
 This recommendation changed once again in the fall of 2019 when NuGet started supporting embedded icons.
 :::
 
-# Documentation of addins
+# Documentation
 
-Addins should follow the [Cake Documentation Guidelines](/community/contributing/documentation) and
-have documentation XML files added to the NuGet package.
+**_§4.1_** **Do** follow the [Cake Documentation Guidelines](/community/contributing/documentation).
 
-:::{.alert .alert-info}
-Proper XML comments and usage of [CakeAliasCategoryAttribute](/api/cake.core.annotations/cakealiascategoryattribute/)
-is important to be able to show documentation for the addin when the it is added to the Cake website.
-:::
+> **Why?** Proper XML comments and usage of [CakeAliasCategoryAttribute](/api/cake.core.annotations/cakealiascategoryattribute/)
+> is important to be able to show documentation for the addin when the it is added to the Cake website.
+
+**_§4.2_** **Do** add documentation XML files to the NuGet package.
+
+> **Why?** XML documentation XML files are used to show documentation for the aliases and API provided by the addin on the Cake website.


### PR DESCRIPTION
Improve addin guidelines by structuring them in individual rules which should make it clearer to see the individual points than to have them written together in a paragraph. For every guidelines there's also an explanation added.

Also changes styling of block quotes to use the default font size. Block quotes seem to be only used in the [Cake.Paket blog post](https://cakebuild.net/blog/2017/01/cake-paket#paket) until now.

![image](https://user-images.githubusercontent.com/2190718/103447314-c12b4100-4c89-11eb-963a-185c7674010b.png)
