### PR TITLE
(GH-43) Add team page

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -35,6 +35,16 @@ var outputPath           = MakeAbsolute(Directory("./output"));
 var rootPublishFolder    = MakeAbsolute(Directory("publish"));
 
 // Definitions
+class MaintainerSpec
+{
+    public string Name { get; set; }
+    public string GitHubUserName { get; set; }
+    public string GitHubID { get; set; }
+    public string Website { get; set; }
+    public string Twitter { get; set; }
+    public string LinkedIn { get; set; }
+}
+
 class ExtensionSpec
 {
     public string Type { get; set; }
@@ -56,6 +66,7 @@ class ExtensionSpec
 }
 
 // Variables
+List<MaintainerSpec> maintainerSpecs = new List<MaintainerSpec>();
 List<ExtensionSpec> extensionSpecs = new List<ExtensionSpec>();
 
 //////////////////////////////////////////////////////////////////////
@@ -131,6 +142,20 @@ Task("CleanExtensionPackages")
     CleanDirectory(extensionDir);
 });
 
+Task("GetMaintainerSpecs")
+    .Does(() =>
+{
+    var maintainerSpecFiles = GetFiles("./maintainers/*.yml");
+    maintainerSpecs
+        .AddRange(maintainerSpecFiles
+            .Select(x =>
+            {
+                Verbose("Deserializing maintainer YAML from " + x);
+                return DeserializeYamlFromFile<MaintainerSpec>(x);
+            })
+        );
+});
+
 Task("GetExtensionSpecs")
     .Does(() =>
 {
@@ -182,6 +207,7 @@ Task("Build")
 
 // Does not download artifacts (run Build or GetArtifacts target first)
 Task("Preview")
+    .IsDependentOn("GetMaintainerSpecs")
     .IsDependentOn("GetExtensionSpecs")
     .Does(context =>
     {
@@ -256,6 +282,7 @@ Task("Default")
 
 Task("GetArtifacts")
     .IsDependentOn("GetSource")
+    .IsDependentOn("GetMaintainerSpecs")
     .IsDependentOn("GetExtensionPackages");
 
 Task("AppVeyor")

--- a/config.wyam
+++ b/config.wyam
@@ -15,6 +15,12 @@ Settings[DocsKeys.IncludeDateInPostPath] = true;
 Settings[DocsKeys.BlogAtomPath] = "blog/feed/atom/index.xml";
 Settings[DocsKeys.BlogRssPath] = "blog/feed/rss/index.xml";
 
+// Reads maintainer metadata
+Pipelines.InsertBefore(Docs.Code, "Maintainers",
+    ReadFiles("../maintainers/*.yml"),
+    Yaml()
+);
+
 // Reads extension metadata
 Pipelines.InsertBefore(Docs.Code, "Extensions",
     ReadFiles("../extensions/*.yml"),

--- a/input/_TeamPage.cshtml
+++ b/input/_TeamPage.cshtml
@@ -1,0 +1,65 @@
+@model IEnumerable<IDocument>
+
+<p>
+    Meet the core Cake maintainer team.
+    Cake would not be possible though without our <a href="/community/thanks/">Sponsors, Backers and Contributors</a>.
+</p>
+
+<div class="row">
+    @foreach(IDocument maintainer in Model.OrderBy(x => Guid.NewGuid()))
+    {
+        string name = maintainer.String("Name");
+        string gitHubUserName = maintainer.String("GitHubUserName");
+        string gitHubID = maintainer.String("GitHubID");
+        string website = maintainer.String("Website");
+        string twitter = maintainer.String("Twitter");
+        string linkedin = maintainer.String("LinkedIn");
+
+        <div class="col-sm-6 col-md-3">
+            <div class="thumbnail">
+                <a title="@name" target="_blank" href="https://github.com/@gitHubUserName">
+                    <img class="team-member-image" src="https://avatars1.githubusercontent.com/u/@gitHubID?v=4">
+                </a>
+                <div class="caption team-member-caption">
+                    <a title="@name" target="_blank" href="https://github.com/@gitHubUserName">
+                        <h3 class="no-anchor">@name</h3>
+                    </a>
+                    <p>
+                        @if (!string.IsNullOrWhiteSpace(website))
+                        {
+                            <a title="Website of @name" target="_blank" href="@website">
+                                <i class="fa fa-globe"></i>
+                            </a>
+                        }
+                        <a title="@name on GitHub" target="_blank" href="https://github.com/@gitHubUserName">
+                            <i class="fa fa-github"></i>
+                        </a>
+                        @if (!string.IsNullOrWhiteSpace(twitter))
+                        {
+                            <a title="@name on Twitter" target="_blank" href="https://twitter.com/@twitter">
+                                <i class="fa fa-twitter"></i>
+                            </a>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(linkedin))
+                        {
+                            <a title="@name on LinkedIn" target="_blank" href="https://www.linkedin.com/in/@linkedin">
+                                <i class="fa fa-linkedin"></i>
+                            </a>
+                        }
+                    </p>
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+<style>
+    .team-member-caption {
+        text-align: center;
+    }
+    .team-member-image {
+        width: 169px;
+        border-radius: 730px;
+        margin: 10px 10px 0 0;
+    }
+</style>

--- a/input/docs/team/index.cshtml
+++ b/input/docs/team/index.cshtml
@@ -1,0 +1,5 @@
+Order: 70
+Description: Maintainer team which brings you Cake
+---
+
+@Html.Partial("_TeamPage", Documents["Maintainers"])

--- a/maintainers/agc93.yml
+++ b/maintainers/agc93.yml
@@ -1,0 +1,6 @@
+Name: Alistair Chapman
+GitHubUserName: agc93
+GitHubID: 1369269
+Website: https://blog.agchapman.com/
+Twitter: agc93
+LinkedIn:

--- a/maintainers/augustoproiete.yml
+++ b/maintainers/augustoproiete.yml
@@ -1,0 +1,6 @@
+Name: C. Augusto Proiete
+GitHubUserName: augustoproiete
+GitHubID: 177608
+Website: https://augustoproiete.net/
+Twitter: augustoproiete
+LinkedIn: augustoproiete

--- a/maintainers/daveaglick.yml
+++ b/maintainers/daveaglick.yml
@@ -1,0 +1,6 @@
+Name: Dave Glick
+GitHubUserName: daveaglick
+GitHubID: 1020407
+Website: https://daveaglick.com/
+Twitter: daveaglick
+LinkedIn: daveaglick

--- a/maintainers/devlead.yml
+++ b/maintainers/devlead.yml
@@ -1,0 +1,6 @@
+Name: Mattias Karlsson
+GitHubUserName: devlead
+GitHubID: 1647294
+Website: https://www.devlead.se/
+Twitter: devlead
+LinkedIn: devlead

--- a/maintainers/ecampidoglio.yml
+++ b/maintainers/ecampidoglio.yml
@@ -1,0 +1,6 @@
+Name: Enrico Campidoglio
+GitHubUserName: ecampidoglio
+GitHubID: 877348
+Website: https://megakemp.com/
+Twitter: ecampidoglio
+LinkedIn: ecampidoglio

--- a/maintainers/gep13.yml
+++ b/maintainers/gep13.yml
@@ -1,0 +1,6 @@
+Name: Gary Ewan Park
+GitHubUserName: gep13
+GitHubID: 1271146
+Website: https://www.gep13.co.uk/
+Twitter: gep13
+LinkedIn: gep13

--- a/maintainers/jericho.yml
+++ b/maintainers/jericho.yml
@@ -1,0 +1,6 @@
+Name: Jérémie Desautels
+GitHubUserName: Jericho
+GitHubID: 112710
+Website:
+Twitter: NorthernNomad
+LinkedIn:

--- a/maintainers/mholo65.yml
+++ b/maintainers/mholo65.yml
@@ -1,0 +1,6 @@
+Name: Martin Björkström
+GitHubUserName: mholo65
+GitHubID: 7863439
+Website: https://martinbjorkstrom.com/
+Twitter: mholo65
+LinkedIn: martin-bjorkstrom

--- a/maintainers/nils-a.yml
+++ b/maintainers/nils-a.yml
@@ -1,0 +1,6 @@
+Name: Nils Andresen
+GitHubUserName: nils-a
+GitHubID: 349188
+Website: https://blog.nils-andresen.de/
+Twitter: nils_andresen
+LinkedIn: nils-andresen-hamburg

--- a/maintainers/pascalberger.yml
+++ b/maintainers/pascalberger.yml
@@ -1,0 +1,6 @@
+Name: Pascal Berger
+GitHubUserName: pascalberger
+GitHubID: 2190718
+Website:
+Twitter: hereispascal
+LinkedIn: hereispascal

--- a/maintainers/patriksvensson.yml
+++ b/maintainers/patriksvensson.yml
@@ -1,0 +1,6 @@
+Name: Patrik Svensson
+GitHubUserName: patriksvensson
+GitHubID: 357872
+Website: https://patriksvensson.se/
+Twitter: firstdrafthell
+LinkedIn: psvensson82


### PR DESCRIPTION
Add a page for presenting the core team. Order is randomized on every generation.

@cake-build/cake-team I added GitHub, Twitter and website for everybody. If you want to have futher links added (code is currently there for LinkedIn) add a comment.

![image](https://user-images.githubusercontent.com/2190718/104130316-4be9fb00-5370-11eb-9a21-06fe9b4f5fa2.png)

Fixes #43
