### PR TITLE
GH-1401: Update Cake.Aws.ElasticBeanstalk.yml: NuGet ID to match nuget.org

### DIFF
--- a/extensions/Cake.Aws.ElasticBeanstalk.yml
+++ b/extensions/Cake.Aws.ElasticBeanstalk.yml
@@ -1,6 +1,6 @@
 Type: Addin
 Name: Cake.AWS.ElasticBeanstalk
-NuGet: Cake.AWS.ElasticBeanstalk
+NuGet: Cake.Aws.ElasticBeanstalk
 Assemblies:
 - "/**/Cake.AWS.ElasticBeanstalk.dll"
 Repository: https://github.com/mathieukempe/Cake.AWS.ElasticBeanstalk.git


### PR DESCRIPTION
Closes #1401