### PR TITLE
Remove Cake specific addin categories

### DIFF
--- a/extensions/Cake.Gerrit.yml
+++ b/extensions/Cake.Gerrit.yml
@@ -8,7 +8,6 @@ ProjectUrl: https://github.com/rhtnr/Cake.Gerrit/
 Author: rhtnr
 Description: Cake addin to post a review/label/comment on Gerrit
 Categories:
-- cake contrib
 - gerrit
 - code
 - review

--- a/extensions/Cake.MinVer.yml
+++ b/extensions/Cake.MinVer.yml
@@ -9,9 +9,6 @@ Author: augustoproiete
 Description: Cake add-in that makes MinVer available as a tool in Cake.
 Categories:
 - minver
-- cake addin
-- cake build
-- cake contrib
 TargetCakeVersion: 0.33.0
 TargetFrameworks:
 - netstandard2.0

--- a/extensions/Cake.SonarResults.yml
+++ b/extensions/Cake.SonarResults.yml
@@ -8,7 +8,6 @@ ProjectUrl: https://github.com/rhtnr/Cake.SonarResults/
 Author: rhtnr
 Description: Package Description
 Categories:
-- cake contrib
 - sonarqube
 - sonar
 TargetCakeVersion: 0.36.0


### PR DESCRIPTION
Remove addin categories which identify addins as Cake addins since this doesn't make sense when shown on the Cake website.