### PR TITLE
Use "Cake Frosting" instead of "Cake.Frosting" everywhere

### DIFF
--- a/input/blog/2020-11-05-cake-v1.0.0-rc0001-released.md
+++ b/input/blog/2020-11-05-cake-v1.0.0-rc0001-released.md
@@ -33,7 +33,7 @@ See [Upgrade instructions](/docs/getting-started/upgrade#cake-0.38.x-to-cake-1.0
 
 ### .NET 5 Support
 
-Cake 1.0 will fully support running natively under .NET 5 both with scripts using the .NET Tool [Cake.Tool](https://cakebuild.net/docs/running-builds/runners/dotnet-core-tool) and as regular .NET Console applications using the [Cake.Frosting](https://cakebuild.net/docs/running-builds/runners/cake-frosting) library.
+Cake 1.0 will fully support running natively under .NET 5 both with scripts using the .NET Tool [Cake.Tool](https://cakebuild.net/docs/running-builds/runners/dotnet-core-tool) and as regular .NET Console applications using the [Cake Frosting](https://cakebuild.net/docs/running-builds/runners/cake-frosting) library.
 
 ### C# 9 support
 

--- a/input/docs/writing-builds/tasks/criteria.md
+++ b/input/docs/writing-builds/tasks/criteria.md
@@ -137,7 +137,7 @@ RunTarget(target);
 
 # Cake Frosting
 
-To implement conditional execution of tasks in [Cake.Frosting] the `ShouldRun` method in the task can be overriden:
+To implement conditional execution of tasks in [Cake Frosting] the `ShouldRun` method in the task can be overriden:
 
 ```csharp
 public sealed class MyTask : FrostingTask<Context>
@@ -161,4 +161,4 @@ See [Cake.Frosting.Example](https://github.com/cake-build/cake/tree/develop/src/
 [Cake .NET Tool]: /docs/running-builds/runners/dotnet-tool
 [Cake runner for .NET Framework]: /docs/running-builds/runners/cake-runner-for-dotnet-framework
 [Cake runner for .NET Core]: /docs/running-builds/runners/cake-runner-for-dotnet-core
-[Cake.Frosting]: /docs/running-builds/runners/cake-frosting
+[Cake Frosting]: /docs/running-builds/runners/cake-frosting

--- a/input/docs/writing-builds/tasks/defining-tasks.md
+++ b/input/docs/writing-builds/tasks/defining-tasks.md
@@ -16,7 +16,7 @@ Task("A")
 
 # Cake Frosting
 
-To define a task in [Cake.Frosting] create a class inheriting from [FrostingTask]:
+To define a task in [Cake Frosting] create a class inheriting from [FrostingTask]:
 
 ```csharp
 [TaskName("A")]
@@ -28,5 +28,5 @@ public class TaskA : FrostingTask
 [Cake .NET Tool]: /docs/running-builds/runners/dotnet-tool
 [Cake runner for .NET Framework]: /docs/running-builds/runners/cake-runner-for-dotnet-framework
 [Cake runner for .NET Core]: /docs/running-builds/runners/cake-runner-for-dotnet-core
-[Cake.Frosting]: /docs/running-builds/runners/cake-frosting
+[Cake Frosting]: /docs/running-builds/runners/cake-frosting
 [FrostingTask]: /api/Cake.Frosting/FrostingTask/


### PR DESCRIPTION
Uses everywhere `Cake Frosting` when mentioning Frosting, instead of `Cake.Frosting`