### PR TITLE
(GH-1538) Add Cake.LongPath.Module.yml

### DIFF
--- a/extensions/Cake.LongPath.Module.yml
+++ b/extensions/Cake.LongPath.Module.yml
@@ -1,0 +1,16 @@
+Type: Module
+Name: Cake.LongPath.Module
+NuGet: Cake.LongPath.Module
+Assemblies:
+- "/**/*.dll"
+Repository: https://github.com/cake-contrib/Cake.LongPath.Module.git
+ProjectUrl: https://github.com/cake-contrib/Cake.LongPath.Module/
+Author: Mattias Karlsson
+Description: The Cake long path module.
+Categories: []
+TargetCakeVersion: 
+TargetFrameworks:
+- net46
+AnalyzedPackageVersion: 0.7.0
+AnalyzedPackageIsPrerelease: false
+AnalyzedPackagePublishDate: 2019-10-26T08:34:08.1770000Z


### PR DESCRIPTION
I don't know why this PR didn't get created by the AddinDiscoverer. I checked the log and it doesn't appear that we triggered abuse detection. We do have logic that stops raising issues and submitting PRs if we think we are close to triggering abuse detection. Maybe this logic kicked in between raising the issue and creating the PR? 

Resolves #1538 