### PR TITLE
Add rules about operating system and platform support

### DIFF
--- a/input/docs/extending/addins/best-practices.md
+++ b/input/docs/extending/addins/best-practices.md
@@ -102,18 +102,22 @@ The wording of each guideline indicates how strong the recommendation is:
 
 ## .NET target version
 
-**_§2.4_** **Consider** to multi-target `netstandard2.0` and `net461`.
+**_§2.4_** **Do** target at least `netstandard2.0`.
+
+> **Why?** Targeting to `netstandard2.0` should work for most addins to support all available Cake runners, operating systems and platforms.
+> Depending on the addin it might be required to target additional platforms.
+
+**_§2.5_** **Consider** to additionally target `net461`.
 
 > **Why?** Since .NET Framework < 4.7.2 has issues with running .NET Standard assemblies, and Cake itself can run on .NET Framework 4.6.1
 > multi-target addins to `netstandard2.0` and `net461` will give the maximum compatibility.
 >
 > Multi-targeting was suggested by Microsoft in [this .NET Conf 2018 talk](https://www.youtube.com/watch?v=hLFyycJVo0I#t=44m48s) and the underlying issues
-> are explained in [this tweet](https://twitter.com/terrajobst/status/1031999730320986112)
+> are explained in [this tweet](https://twitter.com/terrajobst/status/1031999730320986112).
 
-:::{.alert .alert-info}
-This replaces the previous suggestion to only target `netstandard2.0` starting with Cake 0.26.0 as since then issues were found with running `netstandard2.0`
-on .NET Framwork < 4.7.2.
-:::
+**_§2.6_** **Consider** to additionally target `net5.0`.
+
+> **Why?** Targeting `net5.0` additionally to `netstandard2.0` allows you to use features provided by newer platforms when running on .NET 5.
 
 # Package metadata
 
@@ -181,3 +185,24 @@ This recommendation changed once again in the fall of 2019 when NuGet started su
 **_§5.1_** **Do** test the addin with the different [runners](/docs/running-builds/runners).
 
 > **Why?** .NET Tool, script runners and Cake Frosting have slight differences on what dependencies are loaded by the runner and how dependencies are loaded.
+
+:::{.alert .alert-info}
+Runners with which an addin is not compatible should be documented in the XML comment of the class containing the aliases.
+:::
+
+**_§5.2_** **Do** test the addin on all [operating systems](/docs/running-builds/runners/#supported-operating-systems) supported by the different Cake runners.
+
+> **Why?** Different platforms have differences in for example file system or available tools.
+
+:::{.alert .alert-info}
+Operating systems with which an addin is not compatible should be documented in the XML comment of the class containing the aliases.
+:::
+
+**_§5.3_** **Do** test the addin on all [platforms](/docs/running-builds/runners/#supported-platforms) supported by the different Cake runners.
+
+> **Why?** Different platforms have slight differences in implementation and might break an addin.
+> If required, targeting additional frameworks (e.g. `net5.0`) might be required.
+
+:::{.alert .alert-info}
+Platforms, supported by Cake, with which an addin is not compatible should be documented in the XML comment of the class containing the aliases.
+:::


### PR DESCRIPTION
Make rules about operating system and platform support more clear:

- Targeting `netstandard2.0` is now a strong guideline
- Targeting `net461` keeps to be a soft guideline
- Added point about targeting `net5.0` to make use of newest features

This does not change best practices, but should be clearer wording. It also matches what Addin Discoverer checks for (`netstandard2.0` required, everything else optional).

Also adds guidelines that addins should be tested to run on all operating systems and platforms, and if they don't run it should be documented accordingly.

Related to discussions in #1513.