### PR TITLE
Add search box for searching DSL section

### DIFF
--- a/input/_Bottom.cshtml
+++ b/input/_Bottom.cshtml
@@ -1,5 +1,4 @@
 <!-- Search -->
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript">
     docsearch({
         apiKey: '7c45d75e5cd2fddcb761d830d2b8ee27',

--- a/input/_Head.cshtml
+++ b/input/_Head.cshtml
@@ -1,2 +1,3 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript" src="/assets/js/anchor.min.js"></script>

--- a/input/dsl/index.cshtml
+++ b/input/dsl/index.cshtml
@@ -16,3 +16,20 @@ NoSidebar: false
 <p>
     Listed are aliases which are shipped with Cake, but also aliases which are part of community maintained <a href="/extensions">addins</a>.
 </p>
+
+<p>
+    <input type="text" class="form-control" id="search-query-dsl" placeholder="Search aliases" autocomplete="off" autofocus>
+</p>
+
+<script type="text/javascript">
+    docsearch({
+        apiKey: '7c45d75e5cd2fddcb761d830d2b8ee27',
+        indexName: 'cakebuild',
+        inputSelector: '#search-query-dsl',
+        debug: false,
+        algoliaOptions: {
+            facetFilters: ["tags:dsl"],
+            hitsPerPage: 10
+        }
+    });
+</script>


### PR DESCRIPTION
Adds a search box to the DSL reference main page which searches only through all pages below `/dsl`.

![image](https://user-images.githubusercontent.com/2190718/107708407-ba014500-6cc3-11eb-9546-db0d104ad4cd.png)
