### PR TITLE
Add documentation about logging and Spectre.Console

### DIFF
--- a/input/docs/writing-builds/console-output.md
+++ b/input/docs/writing-builds/console-output.md
@@ -1,0 +1,26 @@
+Order: 55
+Description: How to output content to console
+---
+
+# Logging
+
+Cake provides [logging aliases] for writing log messages to the console.
+
+[Logging aliases]: /dsl/logging/
+
+# Advanced output
+
+Cake ships with [Spectre.Console], which provides advanced functionality to output content to the console,
+like [progress bars], [spinners], [tables], [trees], [bar charts] or [FIGlet text].
+
+Use the `AnsiConsole` class to render advanced widgets to the console.
+
+See [Spectre.Console] documentation for details.
+
+[Spectre.Console]: https://spectresystems.github.io/spectre.console/
+[progress bars]: https://spectresystems.github.io/spectre.console/progress
+[spinners]: https://spectresystems.github.io/spectre.console/status
+[tables]: https://spectresystems.github.io/spectre.console/widgets/table
+[trees]: https://spectresystems.github.io/spectre.console/widgets/tree
+[bar charts]: https://spectresystems.github.io/spectre.console/widgets/barchart
+[FIGlet text]: https://spectresystems.github.io/spectre.console/widgets/figlet


### PR DESCRIPTION
Add a page mentioning logging aliases and Spectre.Console capabilities 