### PR TITLE
Add initial redirect URL for users coming from NuGet

### DIFF
--- a/support/nuget/index.aspx
+++ b/support/nuget/index.aspx
@@ -1,0 +1,1 @@
+<% Response.Redirect("https://cakebuild.net/community/getting-help") %>


### PR DESCRIPTION
Redirect `https://cakebuild.net/support/nuget` => `https://cakebuild.net/community/getting-help` to get something working for the NuGet Gallery PR, until we implement the final page