### PR TITLE
Copy NuGet support URL to artifacts for deployment

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -274,9 +274,16 @@ Task("Copy-Bootstrapper-Download")
         CopyDirectory("./download/bootstrapper", outputPath.Combine("bootstrapper"));
     });
 
+Task("Copy-Support-Redirect")
+    .Does(()=>
+    {
+        CopyDirectory("./support/nuget", outputPath.Combine("support/nuget"));
+    });
+
 Task("ZipArtifacts")
     .IsDependentOn("Build")
     .IsDependentOn("Copy-Bootstrapper-Download")
+    .IsDependentOn("Copy-Support-Redirect")
     .Does(() =>
 {
     Zip(outputPath, zipFileName);


### PR DESCRIPTION
Looks like I missed a step on https://github.com/cake-build/website/pull/1718 as Wyam doesn't copy everything in the filesystem to the output folder automatically.