### PR TITLE
Add blog post for sunsetting of .NET Framework and .NET Core runners

### DIFF
--- a/input/blog/2021-10-10-sunsetting-runners.md
+++ b/input/blog/2021-10-10-sunsetting-runners.md
@@ -31,7 +31,7 @@ Cake will continue to support building of .NET Framework projects as well as pro
 Supported platform matrix for Cake 2.0 will look like this:
 
 | Runner                           | .NET 6 | .NET 5 | .NET Core 3.1 |
-|----------------------------------|--------|--------|---------------|
+| -------------------------------- |:------:|:------:|:-------------:|
 | [Cake .NET Tool]                 | <i class="fa fa-check" style="color:green"></i> | <i class="fa fa-check" style="color:green"></i> | <i class="fa fa-check" style="color:green"></i> |
 | [Cake Frosting]                  | <i class="fa fa-check" style="color:green"></i> | <i class="fa fa-check" style="color:green"></i> | <i class="fa fa-check" style="color:green"></i> |
 


### PR DESCRIPTION
Add blog post for sunsetting of .NET Framework and .NET Core runners in Cake 2.0