### PR TITLE
Dotnetmodule Documentation Changes

### DIFF
--- a/extensions/Cake.DotNetTool.Module.yml
+++ b/extensions/Cake.DotNetTool.Module.yml
@@ -15,6 +15,6 @@ TargetFrameworks:
 - net5.0
 - net461
 - netstandard2.0
-AnalyzedPackageVersion: 1.1.0
+AnalyzedPackageVersion: 1.0.1
 AnalyzedPackageIsPrerelease: false
-AnalyzedPackagePublishDate: 2021-03-06T06:37:35.9600000Z
+AnalyzedPackagePublishDate: 2021-02-22T20:53:19.0970000Z

--- a/input/_ExtensionDotNetToolModule.cshtml
+++ b/input/_ExtensionDotNetToolModule.cshtml
@@ -1,0 +1,21 @@
+
+<div class="alert alert-info" role="alert">
+    <p><span class="glyphicon glyphicon-info-sign"></span> .NET tools are now natively supported in Cake builds via <code>#tool dotnet:</code></p>
+    <br>
+    <p>The Cake.DotNetTool Module is bundled with Cake since version 1.1 and is no longer required as a separate package/dependency.
+        Cake.DotNetTool Module will always be released together with Cake and will only be compatible with the specific release.
+        If you use Cake.DotNetTool Module already on your builds do one of the following:
+    </p>
+    <br>
+    <ul>
+        <li>
+            Upgrade Cake to version 1.1.0, and remove the Cake.DotNetTool.Module from your build script (as it's no longer needed)
+        </li>
+        <li>
+            Pin Cake.DotNetTool.Module to a version compatible with the Cake version that you use. 
+            Cake.DotNetTool.Module version 1.0.1 is the last version compatible with Cake 1.0.0.
+            Since version 1.1 Cake.DotNetTool.Module is always released together with Cake and is only compatible with the specific release.
+        </li>
+
+    </ul>
+</div>

--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -27,6 +27,13 @@
 </section>
 
 <section class="content">
+    @{
+        if (name == "Cake.DotNetTool.Module") 
+        {
+            @Html.Partial("_ExtensionDotNetToolModule");
+        }
+    }
+
     <article class="col-sm-8 extension-details no-padding">
         <p class="extension-description">
             @description


### PR DESCRIPTION
Fixes #1739 

Following the suggestion in the issue, a description was added to the DotNetModule extension.
The version of the extension was also reverted back to the previous version.
![cake](https://user-images.githubusercontent.com/23402988/136833197-b0a73193-7fef-41b0-b85d-9acbdb9f1c2f.jpg)


