### PR TITLE
(GH-1248) Add toggle switch to show only built in aliases

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -57,6 +57,13 @@ Pipelines.InsertAfter("Aliases", "DslAliases",
             .Distinct(),
         Documents("Aliases")
     ),
+    Meta(
+        "ContainsBuiltInAliases",
+        @doc
+            .DocumentList(Keys.GroupDocuments)
+            .Any(x => string.IsNullOrWhiteSpace(x.Document(CodeAnalysisKeys.ContainingAssembly)?.String(CodeAnalysisKeys.DisplayName)))
+            ? true
+            : false),
     Meta(Keys.WritePath, new FilePath("dsl/" + @doc.String(Keys.GroupKey).ToLower().Replace(" ", "-") + "/index.html")),
     Meta(Keys.RelativeFilePath, @doc.FilePath(Keys.WritePath)),
     OrderBy(@doc.String(Keys.GroupKey))

--- a/input/_DslLayout.cshtml
+++ b/input/_DslLayout.cshtml
@@ -47,35 +47,45 @@
             }
         }
 
-        // Group heading
-        var groupHeading = addinName ?? "Built-In";
-        <h1 id='@groupHeading.Replace(" ", "-")'>@groupHeading</h1>
+        var aliasClass = isAddin ? "addinAliases" : "builtinAliases";
+        var aliasStyle = isAddin ? "style=display:none;" : null;
+        <div class="aliasList @aliasClass" @aliasStyle>
+            @{
+                // Group heading
+                var groupHeading = addinName ?? "Built-In";
+            }
+            <h1 id='@groupHeading.Replace(" ", "-")'>@groupHeading</h1>
 
-        // Addin annotation
-        @if(isAddin)
-        {
-            @Html.Partial("_AddinAlert", group.FirstOrDefault())
-        }
-
-        // Summary
-        string summary =
-            group
-                .Select(x => x.String(CodeAnalysisKeys.Summary))
-                .FirstOrDefault(x => !string.IsNullOrEmpty(x));
-
-        @if(!string.IsNullOrWhiteSpace(summary))
-        {
-            <p>@Html.Raw(summary)</p>
-        }
-
-        // Alias list
-        @Html.Partial(
-            "_AliasesList",
-            group,
-            new ViewDataDictionary(ViewData)
+            @if(isAddin)
             {
+                // Addin annotation
+                @Html.Partial("_AddinAlert", group.FirstOrDefault());
+            }
+
+            @{
+                // Summary
+                string summary =
+                    group
+                        .Select(x => x.String(CodeAnalysisKeys.Summary))
+                        .FirstOrDefault(x => !string.IsNullOrEmpty(x));
+            }
+
+            @if(!string.IsNullOrWhiteSpace(summary))
+            {
+                <p>@Html.Raw(summary)</p>
+            }
+
+            @{
+                // Alias list
+            }
+            @Html.Partial(
+                "_AliasesList",
+                group,
+                new ViewDataDictionary(ViewData)
+                {
                     { "groupHeadingLevel", 2 }
-            })
+                })
+        </div>
     }
 
     @RenderBody()

--- a/input/_DslSidebar.cshtml
+++ b/input/_DslSidebar.cshtml
@@ -11,10 +11,93 @@
                 group
         ));
     }
+
+    // Flag indicating if current page is for a category containing only aliases from addins.
+    bool isCategoryFromAddin = false;
+    var selectedItem = categories.SingleOrDefault(x => x.Item1 == Model.String(Keys.GroupKey));
+    if (selectedItem != null)
+    {
+        isCategoryFromAddin = !selectedItem.Item2.Bool("ContainsBuiltInAliases");
+    }
+
+    // String to disable filter when current page contains only aliases from addins,
+    // since otherwise page will become empty and be hidden from navigation
+    string showAddinAliasesDisabled = isCategoryFromAddin ? "disabled" : null;
 }
 
-@foreach(Tuple<string, IDocument> category in categories)
-{
-    string selectedClass = category.Item1 == Model.String(Keys.GroupKey) ? "selected" : null;
-    <li class="@selectedClass"><a href="@Context.GetLink(category.Item2)">@category.Item1</a></li>
-}
+<li>
+    <div id="category-filter">
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" class="showAddinAliases" data-toggle="toggle" @showAddinAliasesDisabled checked>
+                <span>Aliases from addins<span>
+            </label>
+        </div>
+    </div>
+
+    <hr>
+
+    <div id="aliasCategories">
+        <ul class="list sidebar-menu" style="display:none;">
+            @foreach(Tuple<string, IDocument> category in categories)
+            {
+                string selectedClass = category.Item1 == Model.String(Keys.GroupKey) ? "selected" : null;
+                bool containsBuiltInAliases = category.Item2.Bool("ContainsBuiltInAliases");
+                <li class="@selectedClass" data-builtin="@containsBuiltInAliases"><a href="@Context.GetLink(category.Item2)">@category.Item1</a></li>
+            }
+        </ul>
+    </div>
+</li>
+
+<link href="//cdn.jsdelivr.net/gh/gitbrent/bootstrap4-toggle@3.6.1/css/bootstrap4-toggle.min.css" rel="stylesheet">
+<script src="//cdn.jsdelivr.net/gh/gitbrent/bootstrap4-toggle@3.6.1/js/bootstrap4-toggle.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.js"></script>
+<script>
+    function showAddinAliases()
+    {
+        // Show categories which only contain aliases from addins
+        categoryList.filter();
+        // List aliases from addins
+        $('div .addinAliases').fadeIn();
+        $.AdminLTE.layout.fix();
+    }
+
+    function hideAddinAliases()
+    {
+        // Hide categories which only contain aliases from addins
+        categoryList.filter(function(item) {
+            return (item.values().builtin == "True");
+        });
+        // Hide aliases from addins
+        $('div .addinAliases').fadeOut();
+        $.AdminLTE.layout.fix();
+    }
+
+    function setAddinAliasesVisibility(visible) {
+        visible ? showAddinAliases() : hideAddinAliases();
+    }
+
+    // Initialize list.js
+    var options = {
+      valueNames: [
+        { data: ['builtin'] }
+      ]
+    };
+    var categoryList = new List('aliasCategories', options);
+
+    var $showAddinAliases = $('.showAddinAliases');
+    $showAddinAliases.on('change', function() {
+        sessionStorage.showAddinAliases = this.checked;
+        setAddinAliasesVisibility(this.checked);
+    });
+
+    // Read initial state for filter from storage.
+    // If currenty category contains only aliases from addins we ignore state (e.g. when direct link to addin category, but toggle previously disabled)
+    var isCategoryFromAddin = @isCategoryFromAddin.ToString().ToLower()
+    $showAddinAliases.prop('checked', isCategoryFromAddin || (( typeof sessionStorage.showAddinAliases !== 'undefined' ) ? (sessionStorage.showAddinAliases === 'true') : true ));
+    $( document ).ready(function() {
+        setAddinAliasesVisibility($showAddinAliases.prop('checked'));
+        $('.sidebar-menu').show();
+        $.AdminLTE.layout.fix();
+    });
+</script>

--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -121,6 +121,12 @@ ul.share-buttons img{
   width: 32px;
 }
 
+// Aliases references
+
+#category-filter {
+  height: 34px;
+}
+
 // Extension list
 
 #search {
@@ -183,6 +189,16 @@ ul.share-buttons img{
   border-color: #dbdbdb;
 }
 
+// Aliases references
+
+#category-filter {
+  height: 34px;
+}
+
+.showAddinAliases {
+  display: none;
+}
+
 // Extension detail page
 
 .extension-description
@@ -230,7 +246,7 @@ ul.share-buttons img{
 }
 
 @media only screen and (max-width: 1670px) and (min-width: 1250px) {
-  // this is the same media-query, as 
+  // this is the same media-query, as
   // https://github.com/Wyamio/Wyam/blob/5008410e87c8c985c57cace0c9b6e2264600d093/themes/Docs/Samson/assets/css/theme/theme.less#L474
   // no variables for those sizes.
   .main-sidebar .sidebar {


### PR DESCRIPTION
Add toggle switch to alias reference page to show only built in aliases.

![image](https://user-images.githubusercontent.com/2190718/136869818-49f9a5be-2200-44e0-9baf-59f86a8ca994.png)

* If toggle is off, all categories containing only aliases from addins will be hidden from left sidebar
* If toggle is off, aliases from addins no longer will be listed for categories containing built-in aliases and aliases from addins
  * There's currently a small issue that they still are shown in the TOC of the page
* Toggle state is persisted across page calls in browser storage
* On pages containing only aliases from addins toggle is disabled, since otherwise page will become empty and be hidden from navigation when toggle is switched off
* On pages containing only aliases form addins persisted browser storage is ignored and toggle is always enabled (use-case is if user has toggle switched off, but accesses page through a direct link)
* Default value of toggle is `On`

Fixes #1248 