### PR TITLE
List GitHub addins in GitHub actions section

### DIFF
--- a/input/docs/integrations/build-systems/github-actions/index.cshtml
+++ b/input/docs/integrations/build-systems/github-actions/index.cshtml
@@ -31,7 +31,7 @@ else
 <h1 id="included-support">Available 3rd party extensions</h1>
 
 @{
-    var keywords = new List<string> { "githubactions" };
+    var keywords = new List<string> { "githubactions", "github" };
     var extensions =
         Documents["Extensions"]
             .Where(x =>


### PR DESCRIPTION
List addins containing the name `GitHub` in the [GitHub Actions integration documentation](https://cakebuild.net/docs/integrations/build-systems/github-actions/).