### PR TITLE
(#2322) Update Cake.Wyam addin dependency to v2.2.13 (supports Cake v2.0.0)

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=Wyam.Tool&version=2.2.9"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=2.2.12"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=2.2.13"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Yaml&version=4.0.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=YamlDotNet&version=6.1.2"
 


### PR DESCRIPTION
Closes #2322
