### PR TITLE
(#2324) Update Cake.FileHelpers addin dependency to v5.0.0 (supports Cake v2.0.0)

### DIFF
--- a/nuget.cake
+++ b/nuget.cake
@@ -1,5 +1,5 @@
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Polly&version=7.2.2"
-#addin "nuget:https://api.nuget.org/v3/index.json??package=Cake.FileHelpers&version=4.0.1"
+#addin "nuget:https://api.nuget.org/v3/index.json??package=Cake.FileHelpers&version=5.0.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=NuGet.Protocol&version=5.11.0"
 
 using System.Net.Http;


### PR DESCRIPTION
Closes #2324
