### PR TITLE
Update videos page with YouTube link

### DIFF
--- a/input/community/resources/videos.md
+++ b/input/community/resources/videos.md
@@ -97,7 +97,7 @@ RedirectFrom: docs/resources/videos
 ### Scott Hanselman - .NET Conf Day 3 Keynote
 #### Cake mentioned at 20:52 in below video
 
-<iframe src="https://channel9.msdn.com/Events/dotnetConf/2016/NET-Conf-Day-3-Keynote-Scott-Hanselman/player" width="640" height="360" allowFullScreen frameBorder="0"></iframe>
+<iframe src="https://www.youtube.com/embed/QVjbXrR-81M" width="640" height="360" allowFullScreen frameBorder="0"></iframe>
 
 ## Motz Codes Live
 ### Continuous Integration for Libraries with Jon Dick aka Redth


### PR DESCRIPTION
The Channel 9 video is no longer at the previous URL. It appears to be available on YouTube, so using the link to that video.

Note: This was the video that YouTube found when I went searching for it. I am unsure if the original was moved elsewhere by Microsoft, or if they have a better host for it.