### PR TITLE
Update setting-up-a-new-scripting-project.md

### DIFF
--- a/input/docs/getting-started/setting-up-a-new-scripting-project.md
+++ b/input/docs/getting-started/setting-up-a-new-scripting-project.md
@@ -55,7 +55,7 @@ Task("Build")
     .IsDependentOn("Clean")
     .Does(() =>
 {
-    DotNetCoreBuild("./src/Example.sln", new DotNetCoreBuildSettings
+    DotNetBuild("./src/Example.sln", new DotNetBuildSettings
     {
         Configuration = configuration,
     });
@@ -65,7 +65,7 @@ Task("Test")
     .IsDependentOn("Build")
     .Does(() =>
 {
-    DotNetCoreTest("./src/Example.sln", new DotNetCoreTestSettings
+    DotNetTest("./src/Example.sln", new DotNetTestSettings
     {
         Configuration = configuration,
         NoBuild = true,


### PR DESCRIPTION
moved to the non-core DotNetTest and DotNetBuild within the sample build.cake.
This removes the obsolete message during run.

This is my first time contributing to a OSS, be gentle.