### PR TITLE
(doc) Fix spelling mistake

### DIFF
--- a/input/docs/writing-builds/preprocessor-directives/load.md
+++ b/input/docs/writing-builds/preprocessor-directives/load.md
@@ -19,7 +19,7 @@ or
 ```
 Attempts to load `utilities.cake` from `scripts` directory.
 
-## Local schem:
+## Local scheme:
 
 ```csharp
 #l "local:?path=scripts/utilities.cake"


### PR DESCRIPTION
schem -> scheme

Once seen, it can't be unseen, and has to be corrected immediately!