### PR TITLE
(doc) Fix spelling mistake

### DIFF
--- a/extensions/Cake.Nuget.Versioning.yml
+++ b/extensions/Cake.Nuget.Versioning.yml
@@ -6,7 +6,7 @@ Assemblies:
 Repository: https://github.com/Kemyke/Cake.Nuget.Versioning.git
 ProjectUrl: https://github.com/Kemyke/Cake.Nuget.Versioning/
 Author: Attila Kemeny
-Description: Contains functionality for creating Nuget compatible version numbers
+Description: Contains functionality for creating NuGet compatible version numbers
 Categories:
 - nuget
 - semver

--- a/input/blog/2016-03-16-cake-v0.10.0-released.md
+++ b/input/blog/2016-03-16-cake-v0.10.0-released.md
@@ -43,7 +43,7 @@ __Features__
 __Improvements__
 
 - [__#740__](https://github.com/cake-build/cake/issues/740) Add dependencies to NuGetPackSettings
-- [__#733__](https://github.com/cake-build/cake/issues/733) Use V3 Nuget in bootstrapper
+- [__#733__](https://github.com/cake-build/cake/issues/733) Use V3 NuGet in bootstrapper
 - [__#732__](https://github.com/cake-build/cake/issues/732) Remove logging from task setup/teardown.
 - [__#708__](https://github.com/cake-build/cake/pull/708) Update ReleaseNotes.md
 - [__#705__](https://github.com/cake-build/cake/pull/705) Removed year from © in readme

--- a/input/blog/2018-04-19-cake-v0.27.0-released.md
+++ b/input/blog/2018-04-19-cake-v0.27.0-released.md
@@ -50,7 +50,7 @@ As part of this release we had [26 issues](https://github.com/cake-build/cake/is
 __Features__
 
 - [__#2078__](https://github.com/cake-build/cake/issues/2078) Support expand environment variables in script pre-processor directives
-- [__#2047__](https://github.com/cake-build/cake/issues/2047) Specify version during Nuget Updating
+- [__#2047__](https://github.com/cake-build/cake/issues/2047) Specify version during NuGet Updating
 - [__#2005__](https://github.com/cake-build/cake/issues/2005) Add entries for Setup/Teardown in report
 - [__#1908__](https://github.com/cake-build/cake/issues/1908) Octopus Deploy tool does not support list-deployments call for octo.exe
 

--- a/input/docs/writing-builds/preprocessor-directives/load.md
+++ b/input/docs/writing-builds/preprocessor-directives/load.md
@@ -28,7 +28,7 @@ or
 ```
 Attempts to load `utilities.cake` from `scripts` directory
 
-## Nuget scheme
+## NuGet scheme
 
 ```csharp
 #l "nuget:?package=utilities.cake"


### PR DESCRIPTION
Nuget - NuGet

Since this is a brand name, we should match it exactly.

Once seen, it can't be unseen, and has to be corrected immediately!