### PR TITLE
(doc) Fix spelling mistake

### DIFF
--- a/input/blog/2017-11-08-intellisense-vscode.md
+++ b/input/blog/2017-11-08-intellisense-vscode.md
@@ -67,4 +67,4 @@ No, at the moment `Cake.CoreCLR` wont work.
 
 **Q: I tried everything above, I still don't get intellisense.**
 
-Submit an issue in the [bakery](https://github.com/cake-build/bakery) repository on Github or reach out to us on [Gitter](https://gitter.im/cake-build/cake).
+Submit an issue in the [bakery](https://github.com/cake-build/bakery) repository on GitHub or reach out to us on [Gitter](https://gitter.im/cake-build/cake).

--- a/input/community/resources/blogs.md
+++ b/input/community/resources/blogs.md
@@ -109,7 +109,7 @@ RedirectFrom: docs/resources/blogs
 
 ## Dariusz Pawlukiewicz
 
-* [Integrating Codecov with .NET Core app, AppVeyor and Github](http://foreverframe.net/integrating-codecov-with-net-core-app-appveyor-and-github/)
+* [Integrating Codecov with .NET Core app, AppVeyor and GitHub](http://foreverframe.net/integrating-codecov-with-net-core-app-appveyor-and-github/)
 
 ## Enrico Campidoglio
 


### PR DESCRIPTION
Github - GitHub

Since this is a brand name, we should match it exactly.

Once seen, it can't be unseen, and has to be corrected immediately!