### PR TITLE
Update Cake.Yaml addin dependency to v5.0.0 (supports Cake v2.0.0)

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 #tool "dotnet:https://api.nuget.org/v3/index.json?package=Wyam.Tool&version=2.2.9"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=2.2.13"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Yaml&version=4.0.0"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=YamlDotNet&version=6.1.2"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Yaml&version=5.0.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=YamlDotNet&version=12.3.1"
 
 #load "nuget.cake"
 #load "github.cake"


### PR DESCRIPTION
Closes #2323
