### PR TITLE
Update to new dotnet install syntax

### DIFF
--- a/input/docs/getting-started/setting-up-a-new-frosting-project.md
+++ b/input/docs/getting-started/setting-up-a-new-frosting-project.md
@@ -18,7 +18,7 @@ You can find the .NET SDK at https://dotnet.microsoft.com/download
 To create a new [Cake Frosting] project you need to install the Frosting template:
 
 ```powershell
-dotnet new --install Cake.Frosting.Template
+dotnet new install Cake.Frosting.Template
 ```
 
 Create a new Frosting project:


### PR DESCRIPTION
Use of `dotnet new --install` is deprecated and has been replaced with 'dotnet new install'.