### PR TITLE
(maint) Update to latest Google Analytics

### DIFF
--- a/input/_Bottom.cshtml
+++ b/input/_Bottom.cshtml
@@ -68,14 +68,12 @@
     }
 </script>
 
-<!-- Google Analytics -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-74Q2C74VR5"></script>
 <script>
-    (function (i, s, o, g, r, a, m) {
-        i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-            (i[r].q = i[r].q || []).push(arguments)
-        }, i[r].l = 1 * new Date(); a = s.createElement(o),
-            m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-    ga('create', 'UA-60516413-1', 'auto');
-    ga('send', 'pageview');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-74Q2C74VR5');
 </script>


### PR DESCRIPTION
The Google Analytics property that we currently have is set to be retired on 1 July 2023.  If you log in, it states:

This property will stop processing data starting 1 July 2023. Use the GA4 Setup Assistant to complete the next steps.

A new property has been created, and this commit updates to use this new property.