### PR TITLE
Use list of contributors as provided by Addin Discoverer

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -21,6 +21,12 @@ Pipelines.InsertBefore(Docs.Code, "Maintainers",
     Yaml()
 );
 
+// Reads contributor metadata
+Pipelines.InsertBefore(Docs.Code, "Contributors",
+    ReadFiles("../contributors/*.yml"),
+    Yaml()
+);
+
 // Reads extension metadata
 Pipelines.InsertBefore(Docs.Code, "Extensions",
     ReadFiles("../extensions/*.yml"),

--- a/input/_ContributorsPage.cshtml
+++ b/input/_ContributorsPage.cshtml
@@ -1,0 +1,31 @@
+@model IEnumerable<IDocument>
+
+<div class="row">
+    @foreach(IDocument contributor in Model.OrderBy(x => Guid.NewGuid()))
+    {
+        string contributorName = contributor.String("Name");
+        string contributorUrl = contributor.String("HtmlUrl");
+        string contributorImage = contributor.String("AvatarUrl");
+        string commitLink = $"https://github.com/search?q=org%3Acake-build+author%3A{contributorName}&type=commits";
+
+        <div class="col-6 col-md-2">
+            <div class="thumbnail contributor-thumbnail">
+                <a title="@contributorName" target="_blank" href="@commitLink">
+                    <img class="contributor-image" src="@contributorImage">
+                </a>
+            </div>
+        </div>
+    }
+</div>
+
+<style>
+    .contributor-image {
+        width: 80px;
+        border-radius: 730px;
+        margin: 10px 10px 0 0;
+    }
+    .contributor-thumbnail {
+        border: none;
+        background-color: transparent;
+    }
+</style>

--- a/input/community/thanks/index.cshtml
+++ b/input/community/thanks/index.cshtml
@@ -6,31 +6,6 @@ RedirectFrom:
   - docs/thanks/index
 ---
 
-@*
-Based on Code from https://github.com/reactiveui/website
-
-The MIT License (MIT)
-
-Copyright (c) 2017 Geoffrey Huntley
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*@
-
 We would like to say thank you to the following people and organizations without whom Cake would not have been possible.
 
 <h1>Sponsors</h1>
@@ -44,85 +19,7 @@ We would like to say thank you to the following people and organizations without
 <h1>Contributors</h1>
 
 <div class="alert alert-info">
-  Listed are GitHub users that have contributed to the following repositories:
-  <a href="https://github.com/cake-build/bakery">bakery</a>,
-  <a href="https://github.com/cake-build/bitrise-cake-step">bitrise-cake-step</a>,
-  <a href="https://github.com/cake-build/cake">cake</a>,
-  <a href="https://github.com/cake-build/cake-action">cake-action</a>,
-  <a href="https://github.com/cake-build/cake-rider">cake-rider</a>,
-  <a href="https://github.com/cake-build/cake-teamcity">cake-teamcity</a>,
-  <a href="https://github.com/cake-build/cake-vs">cake-vs</a>,
-  <a href="https://github.com/cake-build/cake-vscode">cake-vscode</a>,
-  <a href="https://github.com/cake-build/cake-vso">cake-vso</a>,
-  <a href="https://github.com/cake-build/cake-yeoman">cake-yeoman</a>,
-  <a href="https://github.com/cake-build/pantry">pantry</a>,
-  <a href="https://github.com/cake-build/resources">resources</a> and
-  <a href="https://github.com/cake-build/website">website</a>
+  Listed are GitHub users that have contributed to any public repository of the <a href="https://github.com/cake-build">GitHub Cake organization</a>.
 </div>
 
-<div class="contributors"></div>
-
-<script>
-  $.when(
-    $.ajax('https://api.github.com/repos/cake-build/bakery/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/bitrise-cake-step/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/cake/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/cake-action/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/cake-rider/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/cake-teamcity/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/cake-vs/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/cake-vscode/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/cake-vso/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/cake-yeoman/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/pantry/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/resources/contributors?per_page=250'),
-    $.ajax('https://api.github.com/repos/cake-build/website/contributors?per_page=250'))
-  .then(function(bakeryData, bitriseData, cakeData, actionData, riderData, teamcityData, vsData, vscodeData, vsoData, yeomanData, pantryData, resourcesData, websiteData) {
-    var persons = {};
-    var allData =
-      bakeryData[0].
-        concat(bitriseData[0]).
-        concat(cakeData[0]).
-        concat(actionData[0]).
-        concat(riderData[0]).
-        concat(teamcityData[0]).
-        concat(vsData[0]).
-        concat(vscodeData[0]).
-        concat(vsoData[0]).
-        concat(yeomanData[0]).
-        concat(pantryData[0]).
-        concat(resourcesData[0]).
-        concat(websiteData[0]);
-
-    for(var i = 0; i < allData.length; i++) {
-        persons[allData[i].login] = allData[i];
-    }
-
-    // var sortedLogins = Object.keys(persons).sort();
-    var logins = Object.keys(persons);
-    shuffleArray(logins);
-
-    $(logins).each(function (index, login) {
-      var person = persons[login];
-      var img = '<img class="contributor" src="' + person.avatar_url + '" />';
-      $('.contributors')
-        .append('<a title="' + person.login + '" href="' + person.html_url + '">'
-                + img + '</a>');
-    });
-  });
-
-  function shuffleArray(array) {
-    for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [array[i], array[j]] = [array[j], array[i]];
-    }
-  }
-</script>
-
-<style>
-  .contributor {
-    width: 80px;
-    border-radius: 730px;
-    margin: 10px 10px 0 0;
-  }
-</style>
+@Html.Partial("_ContributorsPage", Documents["Contributors"])


### PR DESCRIPTION
Create list of contributors from the static YAML file maintained by addin discoverer instead of reading them on every client request. This helps to ensure that we don't run into rate limiting when reading contributors.

Fixes #2243