### PR TITLE
Remove unnecessary parsing of maintainer files in build script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -34,16 +34,6 @@ var outputPath           = MakeAbsolute(Directory("./output"));
 var rootPublishFolder    = MakeAbsolute(Directory("publish"));
 
 // Definitions
-class MaintainerSpec
-{
-    public string Name { get; set; }
-    public string GitHubUserName { get; set; }
-    public string GitHubID { get; set; }
-    public string Website { get; set; }
-    public string Twitter { get; set; }
-    public string LinkedIn { get; set; }
-}
-
 class ExtensionSpec
 {
     public string Type { get; set; }
@@ -65,7 +55,6 @@ class ExtensionSpec
 }
 
 // Variables
-List<MaintainerSpec> maintainerSpecs = new List<MaintainerSpec>();
 List<ExtensionSpec> extensionSpecs = new List<ExtensionSpec>();
 List<string> assemblies = new List<string>();
 
@@ -142,20 +131,6 @@ Task("CleanExtensionPackages")
     CleanDirectory(extensionDir);
 });
 
-Task("GetMaintainerSpecs")
-    .Does(() =>
-{
-    var maintainerSpecFiles = GetFiles("./maintainers/*.yml");
-    maintainerSpecs
-        .AddRange(maintainerSpecFiles
-            .Select(x =>
-            {
-                Verbose("Deserializing maintainer YAML from " + x);
-                return DeserializeYamlFromFile<MaintainerSpec>(x);
-            })
-        );
-});
-
 Task("GetExtensionSpecs")
     .Does(() =>
 {
@@ -228,7 +203,6 @@ Task("Build")
 
 // Does not download artifacts (run Build or GetArtifacts target first)
 Task("Preview")
-    .IsDependentOn("GetMaintainerSpecs")
     .IsDependentOn("GetExtensionSpecs")
     .Does(context =>
     {
@@ -314,7 +288,6 @@ Task("Default")
 
 Task("GetArtifacts")
     .IsDependentOn("GetSource")
-    .IsDependentOn("GetMaintainerSpecs")
     .IsDependentOn("GetExtensionPackages");
 
 Task("AppVeyor")


### PR DESCRIPTION
Remove unnecessary parsing of maintainer files in build script, since the actual parsing is done by Wyam