### PR TITLE
Mention extension on the contributors page

### DIFF
--- a/input/community/thanks/index.cshtml
+++ b/input/community/thanks/index.cshtml
@@ -18,7 +18,7 @@ We would like to say thank you to the following people and organizations without
 
 <h1>Contributors</h1>
 
-Cake was made possible thanks to the <a href="/docs/team/">Cake team</a> and the contribution of these
+Cake and <a href="/extensions/">Cake extensions</a> were made possible thanks to the <a href="/docs/team/">Cake team</a> and the contribution of these
 awesome @Documents["Contributors"].Count() members of the Cake community listed below:
 
 @Html.Partial("_ContributorsPage", Documents["Contributors"])


### PR DESCRIPTION
Since we're now also list contributors to cake-contrib org we should mention extensions in the introduction. 