### PR TITLE
Update supported version of Cake for Rider

### DIFF
--- a/input/docs/integrations/editors/rider/index.cshtml
+++ b/input/docs/integrations/editors/rider/index.cshtml
@@ -24,7 +24,7 @@ RedirectFrom: docs/editors/rider
 
 <div class="alert alert-info">
     <p>
-        The <a href="https://plugins.jetbrains.com/plugin/15729-cake-rider" target="_blank">Cake plugin for Rider</a> supports Rider version 2022.3 and newer.
+        The <a href="https://plugins.jetbrains.com/plugin/15729-cake-rider" target="_blank">Cake plugin for Rider</a> supports Rider version 2023.1.
     </p>
 </div>
 


### PR DESCRIPTION
Cake for Rider 6.0.0 has been released. The only supported version here is Rider 2023.1.x