### PR TITLE
Update supported version of Cake for Rider

### DIFF
--- a/input/docs/integrations/editors/rider/index.cshtml
+++ b/input/docs/integrations/editors/rider/index.cshtml
@@ -24,7 +24,7 @@ RedirectFrom: docs/editors/rider
 
 <div class="alert alert-info">
     <p>
-        The <a href="https://plugins.jetbrains.com/plugin/15729-cake-rider" target="_blank">Cake plugin for Rider</a> supports Rider version 2023.1.
+        The <a href="https://plugins.jetbrains.com/plugin/15729-cake-rider" target="_blank">Cake plugin for Rider</a> supports Rider version 2024.1.
     </p>
 </div>
 


### PR DESCRIPTION
Cake for Rider 8.0.1 has been released. The only supported version here is Rider 2024.1.x