### PR TITLE
Fix build

### DIFF
--- a/input/_ExtensionsLayout.cshtml
+++ b/input/_ExtensionsLayout.cshtml
@@ -121,7 +121,7 @@
                 <li>
                     <span title="@parsedPublishDate.ToOrdinalWords()">
                         <i class="fa-solid fa-clock-one"></i>
-                        Last updated @parsedPublishDate.Humanize()
+                        Last updated @DateHumanizeExtensions.Humanize(parsedPublishDate)
                     </span>
                 </li>
             }

--- a/input/_ExtensionsList.cshtml
+++ b/input/_ExtensionsList.cshtml
@@ -58,7 +58,7 @@
                         <li>
                             <span title="@parsedPublishDate.ToOrdinalWords()">
                                 <i class="fa-solid fa-clock-one"></i>
-                                Last updated @parsedPublishDate.Humanize()
+                                Last updated @DateHumanizeExtensions.Humanize(parsedPublishDate)
                             </span>
                         </li>
                     }


### PR DESCRIPTION
Humanizer v3.0.0-beta.13 has changed signature of `EnumHumanizeExtension` to a generic class of `T : struct, Enum` so that code tries to call it instead of `DateHumanizeExtension`.  