### PR TITLE
Replace deprecated call with current version

### DIFF
--- a/input/docs/running-builds/runners/cake-frosting.md
+++ b/input/docs/running-builds/runners/cake-frosting.md
@@ -62,7 +62,7 @@ You can find the SDK at https://dotnet.microsoft.com/download
 To create a new Cake Frosting project you need to install the Frosting template:
 
 ```powershell
-dotnet new --install Cake.Frosting.Template
+dotnet new install Cake.Frosting.Template
 ```
 
 Create a new Frosting project:


### PR DESCRIPTION
`dotnet new --install` is deprecated and has been replaced with `dotnet new install`.