### PR TITLE
Remove mention of .NET version on front page

### DIFF
--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -59,7 +59,7 @@ NoGutter: true
         <div class="col-sm-4">
             <h3 class="no-anchor">Cross platform &amp; cross runtime</h3>
             <p>
-                Cake runs on modern .NET platform (.NET Core 3.1 or .NET 5 and newer) and is available on Windows, Linux and macOS.
+                Cake runs on modern .NET platform and is available on Windows, Linux and macOS.
                 See <a href="docs/running-builds/runners">Runners</a> for a list of available runners.
             </p>
         </div>


### PR DESCRIPTION
Remove inaccurate mentioning of .NET versions on the start page. Up to date supported versions are listed on the linked page. 