### PR TITLE
Update Fediverse links

### DIFF
--- a/input/_Footer.cshtml
+++ b/input/_Footer.cshtml
@@ -1,6 +1,7 @@
 <p class="text-muted">
-    <a href="https://github.com/cake-build/cake" target="_blank"><i class="fa-brands fa-github"></i> GitHub</a> |
-    <a href="https://x.com/cakebuildnet" target="_blank"><i class="fa-brands fa-twitter"></i>X</a>
+    <a href="https://github.com/cake-build/cake" target="_blank" title="Cake on GitHub"><i class="fa-brands fa-github"></i> GitHub</a> |
+    <a href="https://x.com/cakebuildnet" target="_blank" title="Cake on X/Twitter"><i class="fa-brands fa-twitter"></i>X</a> |
+    <a href="https://dotnet.social/@@cakebuild" target="_blank" title="Cake in the Fediverse (Mastodon)"><i class="fa-brands fa-mastodon"></i> Fediverse</a>
     <br/>
     Copyright &copy; <a href="http://dotnetfoundation.org" target="_blank">.NET Foundation</a> and contributors.
     <br/>

--- a/maintainers/agc93.yml
+++ b/maintainers/agc93.yml
@@ -4,4 +4,4 @@ GitHubID: 1369269
 Website: https://blog.agchapman.com/
 Twitter: agc93
 LinkedIn:
-Mastodon:
+Mastodon: mastodon.social/@agc93

--- a/maintainers/daveaglick.yml
+++ b/maintainers/daveaglick.yml
@@ -2,6 +2,6 @@ Name: Dave Glick
 GitHubUserName: daveaglick
 GitHubID: 1020407
 Website: https://daveaglick.com/
-Twitter: daveaglick
+Twitter:
 LinkedIn: daveaglick
-Mastodon:
+Mastodon: mastodon.social/@daveaglick


### PR DESCRIPTION
- @agc93 has a Mastodon handle
- @daveaglick "moved" from Twitter to Mastodon
- Add a link to [@cakebuild@dotnet.social](https://dotnet.social/@cakebuild) to the page footer