### PR TITLE
GH3296: Fix template name typo from cakeminimal to cakeminimalfile

### DIFF
--- a/input/blog/2025-11-11-cake-v6.0.0-released.md
+++ b/input/blog/2025-11-11-cake-v6.0.0-released.md
@@ -75,7 +75,7 @@ dotnet new cakefile --name cake
 For the simplest possible setup, you can use the minimal template:
 
 ```bash
-dotnet new cakeminimal --name cake
+dotnet new cakeminimalfile --name cake
 ```
 
 For larger projects, you can organize your code across multiple files:

--- a/input/docs/running-builds/runners/cake-sdk.md
+++ b/input/docs/running-builds/runners/cake-sdk.md
@@ -88,7 +88,7 @@ dotnet new install Cake.Template
 For the simplest possible setup:
 
 ```bash
-dotnet new cakeminimal --name cake
+dotnet new cakeminimalfile --name cake
 ```
 
 This creates a minimal `cake.cs` file with just the essential SDK directive and Information log statement.


### PR DESCRIPTION
- Update blog post to use correct template name cakeminimalfile
- Update cake-sdk documentation to use correct template name cakeminimalfile
- fixes #3296