### PR TITLE
docs: Add Cake.Sdk documentation section

### DIFF
--- a/input/docs/writing-builds/preprocessor-directives/index.cshtml
+++ b/input/docs/writing-builds/preprocessor-directives/index.cshtml
@@ -3,15 +3,34 @@ Description: Available pre-processor directives
 RedirectFrom: docs/fundamentals/preprocessor-directives
 ---
 
-<p>
-  Cake scripts have support for pre-processor line directives, which run before the script is executed.
-  These can be used to reference other scripts, assemblies, namespaces and more.
-</p>
+<ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" href="#dotnettool">Cake .NET Tool</a></li>
+    <li><a data-toggle="tab" href="#sdk">Cake Sdk</a></li>
+    <li><a data-toggle="tab" href="#frosting">Cake.Frosting</a></li>
+</ul>
 
-<div class="alert alert-info">
-  <p>
-    Preprocessor directives are not required or available when running with <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>.
-  </p>
+<div class="tab-content">
+    <div id="dotnettool" class="tab-pane fade in active">
+        <p>
+          Cake scripts have support for pre-processor line directives, which run before the script is executed.
+          These can be used to reference other scripts, assemblies, namespaces and more.
+        </p>
+
+        @Html.Partial("_ChildPages")
+    </div>
+    
+    <div id="sdk" class="tab-pane fade">
+      <p>
+        Cake Sdk has support for pre-processor line directives, which run before the application is compiled.
+      </p>
+      <a href="/docs/writing-builds/sdk/preprocessor-directives">View available pre-processor directives</a>
+    </div>
+    
+    <div id="frosting" class="tab-pane fade">
+        <div class="alert alert-info">
+          <p>
+            Preprocessor directives are not required or available when running with <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>.
+          </p>
+        </div>
+    </div>
 </div>
-
-@Html.Partial("_ChildPages")

--- a/input/docs/writing-builds/sdk/constants.md
+++ b/input/docs/writing-builds/sdk/constants.md
@@ -1,0 +1,87 @@
+Order: 25
+Title: Available Constants
+Description: Built-in constants available in Cake.Sdk
+---
+
+Cake.Sdk automatically generates several constants that are available throughout your build script. These constants provide information about the Cake.Generator version and when the aliases were generated.
+
+# Available Constants
+
+The following constants are automatically generated and available in your Cake script:
+
+| Constant                               | Description                                                                            |
+|----------------------------------------|----------------------------------------------------------------------------------------|
+| `CakeGeneratorDate`                    | The UTC date and time when the aliases were generated (format: `yyyy-MM-dd HH:mm:ssZ`) |
+| `CakeGeneratorVersion`                 | The version of Cake.Generator.Core used to generate the aliases                        |
+| `CakeGeneratorInformationalVersion`    | The full informational version of Cake.Generator.Core, including build metadata        |
+| `CakeGeneratorNuGetVersion`            | The NuGet package version of Cake.Generator.Core                                       |
+
+# Usage
+
+These constants are useful for version tracking and debugging purposes in your Cake scripts. You can use them to display version information or include them in build artifacts.
+
+## Displaying Version Information
+
+Here's an example of how to use these constants in your Cake script:
+
+```csharp
+#:sdk Cake.Sdk
+
+var target = Argument("target", "Default");
+
+Task("Version-Info")
+    .Does(() =>
+    {
+        Information("Generated with Cake.Generator.Core version: {0}", CakeGeneratorVersion);
+        Information("Generation date: {0}", CakeGeneratorDate);
+        Information("Generation informational version: {0}", CakeGeneratorInformationalVersion);
+        Information("Generation NuGet version: {0}", CakeGeneratorNuGetVersion);
+    });
+
+Task("Default")
+    .IsDependentOn("Version-Info");
+
+RunTarget(target);
+```
+
+When you run this task, you'll see output similar to:
+
+```
+════════════════════════════════════════════════════════════════════════════════════════════════════
+ Version-Info
+════════════════════════════════════════════════════════════════════════════════════════════════════
+Generated with Cake.Generator.Core version: 6.0.0.0
+Generation date: 2026-01-03 22:59:28Z
+Generation informational version: 6.0.0+53e8acdf86db6bd1653f495fcb5bb450af9cfd30
+Generation NuGet version: 6.0.0
+```
+
+# Constant Details
+
+## CakeGeneratorDate
+
+The `CakeGeneratorDate` constant contains the UTC date and time when the Cake aliases were generated during the build process. The format is `yyyy-MM-dd HH:mm:ssZ`.
+
+**Example value**: `2026-01-03 22:59:28Z`
+
+## CakeGeneratorVersion
+
+The `CakeGeneratorVersion` constant contains the version number of Cake.Generator.Core that was used to generate the aliases. This is typically a semantic version number.
+
+**Example value**: `6.0.0.0`
+
+## CakeGeneratorInformationalVersion
+
+The `CakeGeneratorInformationalVersion` constant contains the full informational version string, which may include additional build metadata such as commit hash, build date, or other version information.
+
+**Example value**: `6.0.0+53e8acdf86db6bd1653f495fcb5bb450af9cfd30`
+
+## CakeGeneratorNuGetVersion
+
+The `CakeGeneratorNuGetVersion` constant contains the NuGet package version of Cake.Generator.Core. This matches the version that would be used when referencing the package from NuGet.
+
+**Example value**: `6.0.0`
+
+# See also
+
+- [Cake.Generator README](https://github.com/cake-build/generator/blob/main/README.md)

--- a/input/docs/writing-builds/sdk/index.cshtml
+++ b/input/docs/writing-builds/sdk/index.cshtml
@@ -1,0 +1,6 @@
+Order: 100
+Title: Cake.Sdk
+Description: Modern .NET SDK-based application
+---
+
+@Html.Partial("_ChildPages")

--- a/input/docs/writing-builds/sdk/ioc-container.md
+++ b/input/docs/writing-builds/sdk/ioc-container.md
@@ -1,0 +1,204 @@
+Order: 30
+Title: IoC Container
+Description: Register and resolve services using dependency injection
+---
+
+Cake.Sdk provides built-in support for dependency injection using the .NET IoC container. You can register services and resolve them in your tasks using the `IServiceCollection` and `ServiceProvider`.
+
+# Registering services
+
+Register services using the `RegisterServices` partial method. This method is automatically discovered and called during the build initialization.
+
+## Basic service registration
+
+```csharp
+#:sdk Cake.Sdk
+
+public static partial class Program
+{
+    static partial void RegisterServices(IServiceCollection services)
+    {
+        services.AddSingleton<IMyService, MyService>();
+    }
+}
+```
+
+## Registering multiple services
+
+You can register multiple services in the same method:
+
+```csharp
+static partial void RegisterServices(IServiceCollection services)
+{
+    services.AddSingleton<IMyService, MyService>();
+    services.AddTransient<IAnotherService, AnotherService>();
+    services.AddScoped<IDataService, DataService>();
+}
+```
+
+## Service lifetime options
+
+Cake.Sdk supports the standard .NET service lifetime options:
+
+- `AddSingleton` - Creates a single instance for the entire build
+- `AddScoped` - Creates an instance per scope (typically per task execution)
+- `AddTransient` - Creates a new instance each time it's requested
+
+# Resolving services
+
+Resolve services in your tasks using the `ServiceProvider` property:
+
+```csharp
+Task("MyTask")
+    .Does(() =>
+    {
+        var service = ServiceProvider.GetRequiredService<IMyService>();
+        service.DoSomething();
+    });
+```
+
+## Optional service resolution
+
+Use `GetService` for optional dependencies that may not be registered:
+
+```csharp
+Task("MyTask")
+    .Does(() =>
+    {
+        var service = ServiceProvider.GetService<IMyService>();
+        if (service != null)
+        {
+            service.DoSomething();
+        }
+    });
+```
+
+# Registering tasks as dependencies
+
+You can register tasks as dependencies using the IoC container. This is useful for dynamically creating tasks based on configuration or other services:
+
+```csharp
+public static partial class Program
+{
+    static partial void RegisterServices(IServiceCollection services)
+    {
+        // Register MyService
+        services.AddSingleton<IMyService, MyService>();
+        
+        // Injects IOC-Task as a dependency of Build task
+        services.AddSingleton(new Action<IScriptHost>(
+            host => host.Task("IOC-Task")
+                        .IsDependeeOf("Build")
+                        .Does(() => Information("Hello from IOC-Task"))));
+    }
+}
+```
+
+# Example
+
+Here's a complete example showing how to use the IoC container:
+
+## Service interface and implementation
+
+```csharp
+public interface ILoggerService
+{
+    void LogInfo(string message);
+    void LogError(string message);
+}
+
+public class LoggerService : ILoggerService
+{
+    public void LogInfo(string message)
+    {
+        Information($"INFO: {message}");
+    }
+    
+    public void LogError(string message)
+    {
+        Error($"ERROR: {message}");
+    }
+}
+```
+
+## Registering and using the service
+
+```csharp
+#:sdk Cake.Sdk
+
+public static partial class Program
+{
+    static partial void RegisterServices(IServiceCollection services)
+    {
+        services.AddSingleton<ILoggerService, LoggerService>();
+    }
+}
+
+var target = Argument("target", "Default");
+
+Task("Default")
+    .Does(() =>
+    {
+        var logger = ServiceProvider.GetRequiredService<ILoggerService>();
+        logger.LogInfo("Hello from IoC Container!");
+    });
+
+RunTarget(target);
+```
+
+# Multi-file structure
+
+When using a multi-file structure, you can organize your service registrations in separate files:
+
+## Main file (build.cs)
+
+```csharp
+#:sdk Cake.Sdk
+#:property IncludeAdditionalFiles=build/**/*.cs
+
+var target = Argument("target", "Default");
+
+Task("Default")
+    .Does(() =>
+    {
+        var logger = ServiceProvider.GetRequiredService<ILoggerService>();
+        logger.LogInfo("Hello from IoC Container!");
+    });
+
+RunTarget(target);
+```
+
+## IoC registration file (build/IoC.cs)
+
+```csharp
+public static partial class Program
+{
+    static partial void RegisterServices(IServiceCollection services)
+    {
+        services.AddSingleton<ILoggerService, LoggerService>();
+        services.AddSingleton<IBuildService, BuildService>();
+    }
+}
+```
+
+## Service implementations (build/Services.cs)
+
+```csharp
+public interface ILoggerService
+{
+    void LogInfo(string message);
+}
+
+public class LoggerService : ILoggerService
+{
+    public void LogInfo(string message)
+    {
+        Information($"INFO: {message}");
+    }
+}
+```
+
+# See also
+
+- [Additional files](/docs/writing-builds/sdk/preprocessor-directives/additional-files)
+- [.NET Dependency Injection](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection)

--- a/input/docs/writing-builds/sdk/multiple-entry-points.md
+++ b/input/docs/writing-builds/sdk/multiple-entry-points.md
@@ -1,0 +1,300 @@
+Order: 40
+Title: Multiple Entry Points
+Description: Define multiple entry points that execute before top-level main
+---
+
+Cake.Sdk supports multiple entry points using methods prefixed with `Main_*`. These methods are automatically discovered and executed before the top-level main code, allowing you to organize tasks across multiple files and create more modular build scripts.
+
+# Overview
+
+Multiple entry points provide a way to define tasks and setup logic in separate methods that are automatically discovered and executed. This is particularly useful for:
+
+- Organizing tasks by feature or module
+- Creating conditional task registration
+- Building dynamic task structures based on configuration
+- Splitting large build scripts into manageable pieces
+
+# Basic Usage
+
+Define entry points by creating methods prefixed with `Main_` in a `partial class Program`:
+
+```csharp
+#:sdk Cake.Sdk
+
+var target = Argument("target", "Default");
+
+Task("Default")
+    .Does(() =>
+    {
+        Information("Hello from top-level main!");
+    });
+
+RunTarget(target);
+
+public static partial class Program
+{
+    private static void Main_One()
+    {
+        Task(nameof(Main_One))
+            .IsDependeeOf("Clean")
+            .Does(() => Information("Hello from Main_One"));
+    }
+
+    private static void Main_Two()
+    {
+        Task(nameof(Main_Two))
+            .IsDependeeOf("Clean")
+            .Does(() => Information("Hello from Main_Two"));
+    }
+}
+```
+
+## Naming Convention
+
+- Methods must be prefixed with `Main_` to be automatically discovered
+- The method name after `Main_` can be any valid C# identifier
+- Methods must be `static` and can be `private` or `public`
+- Methods must be part of a `partial class Program`
+
+# Execution Order
+
+`Main_*` methods are executed in the following order:
+
+1. All `Main_*` methods are discovered and executed first
+2. Top-level main code (outside of methods) is executed after all `Main_*` methods
+3. `RunTarget` is called at the end
+
+This ensures that tasks defined in `Main_*` methods are available when the top-level code runs.
+
+# Examples
+
+## Basic Multiple Entry Points
+
+Here's a simple example with two entry points:
+
+```csharp
+#:sdk Cake.Sdk
+
+var target = Argument("target", "Default");
+
+Task("Clean")
+    .Does(() => Information("Cleaning..."));
+
+Task("Build")
+    .IsDependentOn("Clean")
+    .Does(() => Information("Building..."));
+
+RunTarget(target);
+
+public static partial class Program
+{
+    private static void Main_PreClean()
+    {
+        Task("PreClean")
+            .IsDependeeOf("Clean")
+            .Does(() => Information("Preparing for clean operation"));
+    }
+
+    private static void Main_PreBuild()
+    {
+        Task("PreBuild")
+            .IsDependeeOf("Build")
+            .Does(() => Information("Preparing for build operation"));
+    }
+}
+```
+
+## Entry Points with Criteria
+
+You can use criteria to conditionally register tasks:
+
+```csharp
+#:sdk Cake.Sdk
+
+var target = Argument("target", "Default");
+var rebuild = HasArgument("rebuild");
+var buildData = new BuildData(rebuild);
+
+Task("Clean")
+    .Does(() => Information("Cleaning..."));
+
+RunTarget(target);
+
+public record BuildData(bool Rebuild);
+
+public static partial class Program
+{
+    static void Main_PreClean()
+    {
+        Task("PreClean")
+            .IsDependeeOf("Clean")
+            .WithCriteria<BuildData>(c => c.Rebuild, nameof(BuildData.Rebuild))
+            .Does(() => Information("Preparing for clean operation"));
+    }
+}
+```
+
+## Entry Points with Task Dependencies
+
+Entry points can define tasks with dependencies:
+
+```csharp
+#:sdk Cake.Sdk
+
+var target = Argument("target", "Default");
+
+Task("Build")
+    .IsDependentOn("Validate")
+    .Does(() => Information("Building..."));
+
+RunTarget(target);
+
+public static partial class Program
+{
+    private static void Main_Setup()
+    {
+        Task("Setup")
+            .Does(() =>
+            {
+                Information("Setting up build environment...");
+            });
+    }
+
+    private static void Main_Validate()
+    {
+        Task("Validate")
+            .IsDependentOn("Setup")
+            .Does(() =>
+            {
+                Information("Validating configuration...");
+            });
+    }
+}
+```
+
+# Use Cases
+
+## Organizing Tasks by Feature
+
+Split your build script into logical modules:
+
+```csharp
+public static partial class Program
+{
+    private static void Main_Testing()
+    {
+        Task("UnitTest")
+            .Does(() => Information("Running unit tests..."));
+
+        Task("IntegrationTest")
+            .IsDependentOn("UnitTest")
+            .Does(() => Information("Running integration tests..."));
+    }
+
+    private static void Main_Packaging()
+    {
+        Task("Pack")
+            .Does(() => Information("Packing artifacts..."));
+
+        Task("Publish")
+            .IsDependentOn("Pack")
+            .Does(() => Information("Publishing artifacts..."));
+    }
+}
+```
+
+## Conditional Task Registration
+
+Register tasks based on configuration or arguments:
+
+```csharp
+public static partial class Program
+{
+    private static void Main_ConditionalTasks()
+    {
+        if (HasArgument("include-tests"))
+        {
+            Task("RunTests")
+                .IsDependeeOf("Build")
+                .Does(() => Information("Running tests..."));
+        }
+    }
+}
+```
+
+## Dynamic Task Creation
+
+Create tasks dynamically based on configuration:
+
+```csharp
+public static partial class Program
+{
+    private static void Main_DynamicTasks()
+    {
+        var environments = new[] { "Dev", "Staging", "Production" };
+        
+        foreach (var env in environments)
+        {
+            Task($"Deploy-{env}")
+                .Does(() => Information($"Deploying to {env}..."));
+        }
+    }
+}
+```
+
+# Multi-file Structure
+
+When using a multi-file structure, you can organize `Main_*` methods across multiple files:
+
+## Main file (build.cs)
+
+```csharp
+#:sdk Cake.Sdk
+#:property IncludeAdditionalFiles=build/**/*.cs
+
+var target = Argument("target", "Default");
+
+Task("Default")
+    .Does(() => Information("Hello from main file!"));
+
+RunTarget(target);
+```
+
+## Task definitions file (build/Task.cs)
+
+```csharp
+public static partial class Program
+{
+    static void Main_PreClean()
+    {
+        Task("PreClean")
+            .IsDependeeOf("Clean")
+            .WithCriteria<BuildData>(c => c.Rebuild, nameof(BuildData.Rebuild))
+            .Does(() => Information("Preparing for clean operation"));
+    }
+}
+```
+
+## Additional task file (build/Testing.cs)
+
+```csharp
+public static partial class Program
+{
+    private static void Main_Testing()
+    {
+        Task("UnitTest")
+            .Does(() => Information("Running unit tests..."));
+
+        Task("IntegrationTest")
+            .IsDependentOn("UnitTest")
+            .Does(() => Information("Running integration tests..."));
+    }
+}
+```
+
+All `Main_*` methods across all included files will be automatically discovered and executed before the top-level main code.
+
+# See also
+
+- [Additional files](/docs/writing-builds/sdk/preprocessor-directives/additional-files)
+- [IoC Container](/docs/writing-builds/sdk/ioc-container)

--- a/input/docs/writing-builds/sdk/preprocessor-directives/additional-files.md
+++ b/input/docs/writing-builds/sdk/preprocessor-directives/additional-files.md
@@ -1,0 +1,128 @@
+Order: 60
+Title: Additional files
+Description: Organize code across multiple files in file-based Cake apps
+---
+
+For larger file-based Cake apps, you can organize your code into multiple files. Use the `IncludeAdditionalFiles` and `ExcludeAdditionalFiles` properties to control which files are included during compilation. This allows you to place models, utility functions, and other code in separate files.
+
+# Usage
+
+Use the `#:property` directive to specify which additional files should be included or excluded during compilation.
+
+## Include additional files
+
+Use `IncludeAdditionalFiles` to specify which files should be included:
+
+```csharp
+#:sdk Cake.Sdk
+#:property IncludeAdditionalFiles=build/**/*.cs
+```
+
+This will include all `.cs` files in the `build` directory and its subdirectories.
+
+## Exclude additional files
+
+Use `ExcludeAdditionalFiles` to specify which files should be excluded:
+
+```csharp
+#:sdk Cake.Sdk
+#:property IncludeAdditionalFiles=build/**/*.cs
+#:property ExcludeAdditionalFiles=build/**/Except*.cs
+```
+
+This will include all `.cs` files in the `build` directory, except for files that match the `ExcludeAdditionalFiles` pattern.
+
+# Example
+
+Here's a complete example showing how to organize a multi-file Cake app:
+
+## Main build file (build.cs)
+
+```csharp
+#:sdk Cake.Sdk
+#:property IncludeAdditionalFiles=build/**/*.cs
+#:property ExcludeAdditionalFiles=build/**/Except*.cs
+
+var target = Argument("target", "Default");
+var config = new BuildConfiguration 
+{ 
+    ProjectName = "MyProject",
+    Version = "1.0.0" 
+};
+
+Task("Default")
+    .Does(() =>
+{
+    BuildUtilities.LogInfo($"Building {config.ProjectName} v{config.Version}");
+});
+
+RunTarget(target);
+```
+
+## Models file (build/Models.cs)
+
+```csharp
+public class BuildConfiguration
+{
+    public string ProjectName { get; set; } = "";
+    public string Version { get; set; } = "";
+}
+```
+
+## Utilities file (build/Utilities.cs)
+
+```csharp
+public static partial class Program
+{
+    public static void LogInfo(string message)
+    {
+        Information($"INFO: {message}");
+    }
+}
+```
+
+## Excluded file (build/ExceptThisFile.cs)
+
+```csharp
+// This class will not be compiled.
+public class UnusedLogic
+{
+}
+```
+
+The `ExceptThisFile.cs` file will not be compiled because it matches the `ExcludeAdditionalFiles` pattern.
+
+# Pattern syntax
+
+Both `IncludeAdditionalFiles` and `ExcludeAdditionalFiles` support glob patterns:
+
+- `**` - Matches any number of directories
+- `*` - Matches any number of characters (except path separators)
+- `?` - Matches a single character
+- `[abc]` - Matches any character in the set
+
+## Examples
+
+Include all C# files in a specific directory:
+
+```csharp
+#:property IncludeAdditionalFiles=build/**/*.cs
+```
+
+Include files from multiple directories:
+
+```csharp
+#:property IncludeAdditionalFiles=build/**/*.cs;scripts/**/*.cs
+```
+
+Exclude test files:
+
+```csharp
+#:property IncludeAdditionalFiles=build/**/*.cs
+#:property ExcludeAdditionalFiles=build/**/*Test*.cs
+```
+
+# See also
+
+- [#:property directive](/docs/writing-builds/sdk/preprocessor-directives/property)
+- [File-based apps - .NET | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps)

--- a/input/docs/writing-builds/sdk/preprocessor-directives/index.cshtml
+++ b/input/docs/writing-builds/sdk/preprocessor-directives/index.cshtml
@@ -1,0 +1,5 @@
+Order: 10
+Description: Available pre-processor directives
+---
+
+@Html.Partial("_ChildPages")

--- a/input/docs/writing-builds/sdk/preprocessor-directives/package.md
+++ b/input/docs/writing-builds/sdk/preprocessor-directives/package.md
@@ -1,0 +1,46 @@
+Order: 30
+Title: Package directive
+Description: Directive to fetch assemblies from NuGet
+---
+
+The package directive is used to fetch assemblies from NuGet packages. This is equivalent to adding a `PackageReference` in a `.csproj` file.
+
+# Usage
+
+The directive has one parameter which is the package name, optionally followed by a version.
+
+## Reference NuGet package
+
+```csharp
+#:package Newtonsoft.Json@13.0.4
+```
+
+This is equivalent to the following `.csproj`:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+</ItemGroup>
+```
+
+## Reference Cake packages
+
+You can reference Cake addins and modules:
+
+```csharp
+#:package Cake.Slack@5.0.0
+#:package Cake.BuildSystems.Module@8.0.0
+```
+
+These are equivalent to the following `.csproj`:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Cake.Slack" Version="5.0.0" />
+  <PackageReference Include="Cake.BuildSystems.Module" Version="8.0.0" />
+</ItemGroup>
+```
+
+# See also
+
+- [File-based apps - .NET | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps)

--- a/input/docs/writing-builds/sdk/preprocessor-directives/project.md
+++ b/input/docs/writing-builds/sdk/preprocessor-directives/project.md
@@ -1,0 +1,36 @@
+Order: 40
+Title: Project directive
+Description: Directive to reference C# projects
+---
+
+The project directive is used to reference other C# project files or directories that contain a project file. This is equivalent to adding a `ProjectReference` in a `.csproj` file.
+
+# Usage
+
+The directive has one parameter which is the path to the project file or directory containing a project file.
+
+## Reference project file
+
+```csharp
+#:project ../SharedLibrary/SharedLibrary.csproj
+```
+
+This is equivalent to the following `.csproj`:
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="../SharedLibrary/SharedLibrary.csproj" />
+</ItemGroup>
+```
+
+## Reference project directory
+
+You can also reference a directory that contains a project file:
+
+```csharp
+#:project ../SharedLibrary
+```
+
+# See also
+
+- [File-based apps - .NET | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps)

--- a/input/docs/writing-builds/sdk/preprocessor-directives/property.md
+++ b/input/docs/writing-builds/sdk/preprocessor-directives/property.md
@@ -1,0 +1,38 @@
+Order: 20
+Title: Property directive
+Description: Directive to set MSBuild property values
+---
+
+The property directive is used to set MSBuild property values. This is equivalent to specifying properties in a `.csproj` file.
+
+# Usage
+
+The directive uses the format `PropertyName=PropertyValue`.
+
+## Set MSBuild property
+
+```csharp
+#:property LangVersion=preview
+```
+
+This is equivalent to the following `.csproj`:
+
+```xml
+<PropertyGroup>
+  <LangVersion>preview</LangVersion>
+</PropertyGroup>
+```
+
+## Multiple properties
+
+You can specify multiple properties by using multiple directives:
+
+```csharp
+#:property LangVersion=preview
+#:property TargetFramework=net10.0
+#:property PublishAot=false
+```
+
+# See also
+
+- [File-based apps - .NET | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps)

--- a/input/docs/writing-builds/sdk/preprocessor-directives/sdk.md
+++ b/input/docs/writing-builds/sdk/preprocessor-directives/sdk.md
@@ -1,0 +1,56 @@
+Order: 10
+Title: SDK directive
+Description: Directive to reference .NET SDK from NuGet
+---
+
+The SDK directive is used to reference a .NET SDK from NuGet. This is equivalent to specifying the SDK in a `.csproj` file.
+
+# Usage
+
+The directive has one parameter which is the SDK name, optionally followed by a version.
+
+## Reference SDK from NuGet
+
+```csharp
+#:sdk Cake.Sdk
+```
+
+This is equivalent to the following `.csproj`:
+
+```xml
+<Project Sdk="Cake.Sdk" />
+```
+
+## Reference SDK from NuGet with version
+
+You can specify a version in two ways:
+
+### Versioned in global.json
+
+```csharp
+#:sdk Cake.Sdk@6.0.0
+```
+
+This is equivalent to the following `.csproj`:
+
+```xml
+<Project Sdk="Cake.Sdk/6.0.0" />
+```
+
+### Versioned in file
+
+The version can also be specified directly in the directive:
+
+```csharp
+#:sdk Cake.Sdk@6.0.0
+```
+
+This is equivalent to the following `.csproj`:
+
+```xml
+<Project Sdk="Cake.Sdk/6.0.0" />
+```
+
+# See also
+
+- [File-based apps - .NET | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps)

--- a/input/docs/writing-builds/sdk/preprocessor-directives/shebang.md
+++ b/input/docs/writing-builds/sdk/preprocessor-directives/shebang.md
@@ -1,0 +1,51 @@
+Order: 50
+Title: Shebang directive
+Description: Directive to define the interpreter for Unix-like systems
+---
+
+Under Unix-like operating systems, when a script with a shebang is run as a program, the program loader parses the rest of the script's initial line as an interpreter directive; the specified interpreter program is run instead, passing to it as an argument the path that was initially used when attempting to run the script.
+
+Support for `#!` directives applies on Unix platforms only.
+
+# Usage
+
+Add a shebang at the top of your file:
+
+```bash
+#!/usr/local/share/dotnet/dotnet
+```
+
+or
+
+```bash
+#!/usr/bin/env dotnet
+```
+
+## Make file executable
+
+After adding the shebang, make the file executable:
+
+```bash
+chmod +x cake.cs
+```
+
+## Run directly
+
+You can then run the file directly:
+
+```bash
+./cake.cs
+```
+
+# Example
+
+```csharp
+#!/usr/bin/env dotnet
+#:sdk Cake.Sdk
+
+Information("Hello, {0}!", "World");
+```
+
+# See also
+
+- [File-based apps - .NET | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps)

--- a/input/docs/writing-builds/sdk/tools.md
+++ b/input/docs/writing-builds/sdk/tools.md
@@ -1,0 +1,77 @@
+Order: 20
+Title: Installing and using tools
+Description: How to install and use external tools with Cake.Sdk
+---
+
+Cake.Sdk provides the `InstallTool` method to download and install tool executables available as NuGet packages as part of a build.
+
+# Installing tools with InstallTool
+
+[Cake.Sdk] provides an `InstallTool` method to download a tool and install it:
+
+:::{.alert .alert-info}
+Out of the box NuGet and .NET Tools (since Cake 1.1) are supported as provider.
+More providers are available through [Modules](/extensions/).
+:::
+
+The following example downloads the [GitVersion.Tool package](https://www.nuget.org/packages/GitVersion.Tool)
+as part of executing your build script:
+
+```csharp
+#:sdk Cake.Sdk
+
+var target = Argument("target", "Pack");
+
+Setup(context =>
+{
+    InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=6.3.0");
+    var version = GitVersion();
+
+    Information("Building Version: {0}", version.FullSemVer);
+});
+```
+
+## Installing from NuGet
+
+You can install tools from NuGet using the `nuget:` provider:
+
+```csharp
+Setup(context =>
+{
+    InstallTool("nuget:?package=xunit.runner.console&version=2.4.1");
+});
+```
+
+## Installing .NET Tools
+
+You can install .NET Tools using the `dotnet:` provider:
+
+```csharp
+Setup(context =>
+{
+    InstallTool("dotnet:?package=GitVersion.Tool&version=6.3.0");
+});
+```
+
+You can also specify a custom NuGet source:
+
+```csharp
+Setup(context =>
+{
+    InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=6.3.0");
+});
+```
+
+:::{.alert .alert-info}
+For more information about supported URI string parameters see [#tool pre-processor directive] for [Cake .NET Tool].
+:::
+
+# Installing tools from other providers
+
+Out of the box NuGet and .NET Tools (since Cake 1.1) is supported as provider for `InstallTool`.
+More providers are available through [Modules](/extensions/).
+
+
+[Cake.Sdk]: /docs/running-builds/runners/cake-sdk
+[Cake .NET Tool]: /docs/running-builds/runners/dotnet-tool
+[#tool pre-processor directive]: /docs/writing-builds/preprocessor-directives/tool/

--- a/input/docs/writing-builds/tools/installing-tools.md
+++ b/input/docs/writing-builds/tools/installing-tools.md
@@ -8,10 +8,10 @@ RedirectFrom: docs/tools/installing-tools
 
 Cake provides different ways to install tool executables available as NuGet packages as part of a build.
 
-| Installation method              | Cake .NET Tool | Cake Frosting |
-|----------------------------------|----------------|---------------|
-| [Pre-processor directive]        | <i class="fa-solid fa-check" style="color:green"></i> | <i class="fa-solid fa-xmark" style="color:red"></i>   |
-| [InstallTool]                    | <i class="fa-solid fa-xmark" style="color:red"></i>   | <i class="fa-solid fa-check" style="color:green"></i> |
+| Installation method              | Cake .NET Tool | Cake Frosting | Cake.Sdk |
+|----------------------------------|----------------|---------------|----------|
+| [Pre-processor directive]        | <i class="fa-solid fa-check" style="color:green"></i> | <i class="fa-solid fa-xmark" style="color:red"></i>   | <i class="fa-solid fa-xmark" style="color:red"></i>   |
+| [InstallTool]                    | <i class="fa-solid fa-xmark" style="color:red"></i>   | <i class="fa-solid fa-check" style="color:green"></i> | <i class="fa-solid fa-check" style="color:green"></i> |
 
 ## Installing tools via pre-processor directive
 
@@ -35,12 +35,14 @@ For more information see [#tool pre-processor directive].
 
 ## Installing tools with InstallTool
 
-[Cake Frosting] provides a `InstallTool` method to download a tool and install it:
+[Cake Frosting] and [Cake.Sdk] provide an `InstallTool` method to download a tool and install it:
 
 :::{.alert .alert-info}
 Out of the box NuGet and .NET Tools (since Cake 1.1) are supported as provider.
 More providers are available through [Modules](/extensions/).
 :::
+
+### Cake Frosting
 
 The following example downloads the [xunit.runner.console package](https://www.nuget.org/packages/xunit.runner.console)
 as part of executing your build script:
@@ -58,6 +60,26 @@ public class Program : IFrostingStartup
     }
 }
 ```
+
+### Cake.Sdk
+
+The following example downloads the [GitVersion.Tool package](https://www.nuget.org/packages/GitVersion.Tool)
+as part of executing your build script:
+
+```csharp
+#:sdk Cake.Sdk
+
+Setup(context =>
+{
+    InstallTool("dotnet:https://api.nuget.org/v3/index.json?package=GitVersion.Tool&version=6.3.0");
+    var version = GitVersion();
+    Information("Building Version: {0}", version.FullSemVer);
+});
+```
+
+:::{.alert .alert-info}
+For more information about using tools with Cake.Sdk see [Installing and using tools with Cake.Sdk](/docs/writing-builds/sdk/tools).
+:::
 
 :::{.alert .alert-info}
 For more information about supported URI string parameters see [#tool pre-processor directive].
@@ -87,6 +109,7 @@ Task("Install-XUnit")
 
 [Cake .NET Tool]: /docs/running-builds/runners/dotnet-tool
 [Cake Frosting]: /docs/running-builds/runners/cake-frosting
+[Cake.Sdk]: /docs/running-builds/runners/cake-sdk
 [Pre-processor directive]: #installing-tools-via-pre-processor-directive
 [InstallTool]: #installing-tools-with-installtool
 [Bootstrapper]: #installing-tools-via-bootstrapper


### PR DESCRIPTION
Add comprehensive documentation for Cake.Sdk including preprocessor directives, constants, IoC container, multiple entry points, and tools. Update preprocessor directives page with runner-specific tabs and enhance tools installation docs with Cake.Sdk support.