### PR TITLE
Add Cake.Sdk 6.1.1 note and clarify runner options on homepage

### DIFF
--- a/input/blog/2026-03-01-cake-v6.1.0-released.md
+++ b/input/blog/2026-03-01-cake-v6.1.0-released.md
@@ -9,6 +9,8 @@ Version **6.1.0** of Cake has been released. Take it for a spin and give us feed
 
 This release includes new features, improvements, and bug fixes to both [Cake Scripting](/docs/running-builds/runners/dotnet-tool), [Cake Frosting](/docs/running-builds/runners/cake-frosting), and [Cake Sdk](/docs/running-builds/runners/cake-sdk) since the [Cake v6.0.0 release](/blog/2025/11/cake-v6.0.0-released)! 🚀 🍰
 
+**Update:** Cake.Sdk **6.1.1** has been released to address a dependency issue. If you use [Cake.Sdk](/docs/running-builds/runners/cake-sdk), we recommend updating to 6.1.1.
+
 ### Highlights of this release
 
 - **FormattableString support in logging** — Use interpolated strings and `FormattableLogAction` with `Error`, `Warning`, `Information`, `Verbose`, and `Debug` for cleaner logging.

--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -52,8 +52,9 @@ NoGutter: true
             <h3 class="no-anchor">Familiar</h3>
             <p>
                 Cake is built on top of the Roslyn compiler which enables you to write your build scripts in pure C# in
-                either a standard console project, using <a href="docs/running-builds/runners/cake-frosting">Cake Frosting</a>,
-                or as Cake script using <a href="docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a>.
+                either a single-file app using <a href="docs/running-builds/runners/cake-sdk">Cake.Sdk</a>, 
+                a standard console project using <a href="docs/running-builds/runners/cake-sdk">Cake.Sdk</a> / <a href="docs/running-builds/runners/cake-frosting">Cake Frosting</a>, 
+                or as a Cake script using <a href="docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a>.
             </p>
         </div>
         <div class="col-sm-4">


### PR DESCRIPTION
- Note Cake.Sdk 6.1.1 in v6.1.0 blog post (dependency fix)
- List single-file app (Cake.Sdk), console (Cake.Sdk/Frosting), and script (.NET Tool) on index