### PR TITLE
style: improve light mode contrast for blog sidebar headers( categories and archive)

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -266,7 +266,7 @@ ul.share-buttons img{
   }
 }
 
-// Sidebar header color overrides for blog (Category and Archive) @priyanshupaikra
+// Sidebar header color overrides for blog (Category and Archive)
 .sidebar-menu li.header {
     color: darkgrey !important;
 }


### PR DESCRIPTION
<img width="1249" height="284" alt="Screenshot 2026-03-09 182514" src="https://github.com/user-attachments/assets/837325a6-655b-45a3-a311-749bea6f1940" />

### Summary
This PR fixes the low contrast issue in light mode for the blog sidebar, specifically the *Categories* and *Archive* section headers.

### Problem
In light mode, the header text color for the Categories and Archive sections had low contrast against the background, making it difficult to read.

### Solution
Updated the header text color to a darker grey to improve readability and maintain better visual consistency with the rest of the UI.

### Changes
* Updated the CSS color for blog sidebar headers
* Improved visibility in light mode

### Related Issue
Fixes cake-build/cake#4726