### PR TITLE
Add RSS discovery link for blog feed

### DIFF
--- a/input/_Head.cshtml
+++ b/input/_Head.cshtml
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<link rel="alternate" type="application/rss+xml" title="Cake Blog RSS" href="/blog/feed/rss/" />
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript" src="/assets/js/anchor.min.js"></script>
 <link href="https://dotnet.social/@@cakebuild" rel="me">


### PR DESCRIPTION
This PR adds an RSS discovery link to the site <head> so RSS readers can automatically detect the Cake blog feed.

The RSS feed already exists, but it was not advertised in the page metadata.

Fixes #3287