### PR TITLE
docs : add command line instructions for CI servers

### DIFF
--- a/input/docs/integrations/build-systems/azure-pipelines/azure-devops-build-task-extension.md
+++ b/input/docs/integrations/build-systems/azure-pipelines/azure-devops-build-task-extension.md
@@ -46,3 +46,11 @@ To use the bootstrapper file you should add a "PowerShell" or "Shell Script" tas
 Environment Variables which are marked secret in Azure DevOps, can by default not be resolved using `EnvironmentVariable()` in a Cake script.
 They can be passed as arguments to the build script or explicitly mapped in using a YAML build definition.
 You can read more about this limitation in the [Azure DevOps documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=vsts&tabs=yaml%2Cbatch#secret-variables).
+
+## Usage with Command Line
+
+You can also run Cake using a standard command line task instead of the extension:
+
+```yaml
+- script: dotnet cake
+  displayName: 'Run Cake'

--- a/input/docs/integrations/build-systems/azure-pipelines/command-line.md
+++ b/input/docs/integrations/build-systems/azure-pipelines/command-line.md
@@ -1,0 +1,17 @@
+---
+Order: 20
+Title: GitHub Actions Command Line
+Description: Running Cake in GitHub Actions using the run command.
+---
+
+# Run via Command Line
+
+To run Cake in GitHub Actions using the standard command line, add a `run` step to your workflow.
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run Cake
+      run: dotnet cake


### PR DESCRIPTION
Closes #2292. Added documentation for running Cake via the command line for Azure Pipelines and GitHub Actions