### PR TITLE
fix: update broken bootstrapper links to correct path

### DIFF
--- a/input/docs/running-builds/runners/deprecated/cake-runner-for-dotnet-framework.md
+++ b/input/docs/running-builds/runners/deprecated/cake-runner-for-dotnet-framework.md
@@ -175,8 +175,8 @@ Cake uses [Azure Artifacts](https://dev.azure.com/cake-build/Cake/_packaging?_a=
 With these pre-release builds the next version of Cake can be accessed and utilized for getting the latest features or testing addins or build scripts to know if the next release will be safe when you need to upgrade.
 
 :::{.alert .alert-info}
-These instructions assume you are using the NuGet CLI as done in the [default bootstrapper for Windows](https://github.com/cake-build/resources/blob/develop/build.ps1)
-or [default bootstrapper for macOS & Linux](https://github.com/cake-build/resources/blob/develop/build.sh).
+These instructions assume you are using the NuGet CLI as done in the [default bootstrapper for Windows](https://github.com/cake-build/resources/blob/master/dotnet-framework/build.ps1)
+or [default bootstrapper for macOS & Linux](https://github.com/cake-build/resources/blob/master/dotnet-framework/build.sh).
 :::
 
 1. Update the bootstrapper


### PR DESCRIPTION
## What's broken
Two links in `cake-runner-for-dotnet-framework.md` were returning 404 because they pointed to a `develop` branch that no longer exists.

## What I changed
Updated both broken links to the correct path:
- `blob/develop/build.ps1` → `blob/master/dotnet-framework/build.ps1`
- `blob/develop/build.sh` → `blob/master/dotnet-framework/build.sh`

Closes #3391