### PR TITLE
Added logging documentation

### DIFF
--- a/input/docs/fundamentals/logging.md
+++ b/input/docs/fundamentals/logging.md
@@ -1,0 +1,19 @@
+---
+Title: Logging
+---
+
+# Logging
+
+Cake provides built-in logging aliases that can be used to write log messages during builds.
+
+## Built-in Logging Aliases
+
+Cake contains several aliases for logging information, warnings, errors, and verbose messages during execution.
+
+These aliases help display useful build information in the console output.
+
+## Spectre.Console Support
+
+Cake ships with Spectre.Console for advanced console output and formatting capabilities.
+
+This provides improved console rendering and enhanced logging experiences.


### PR DESCRIPTION
Added a logging documentation page under fundamentals.

This documentation includes:

* built-in logging aliases
* Spectre.Console support for advanced console output
