### PR TITLE
GH2292: Document Cake.Sdk and Frosting in CI integration guides

### DIFF
--- a/input/docs/integrations/build-systems/appveyor/index.cshtml
+++ b/input/docs/integrations/build-systems/appveyor/index.cshtml
@@ -35,12 +35,36 @@ else
 <h1 id="running-cake">Running Cake</h1>
 
 <p>
-    The recommended way to run Cake on AppVeyor is by using a tool manifest:
+    The recommended way to run the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a> on AppVeyor is by using a tool manifest:
 </p>
 
 <pre><code class="language-yaml hljs">build_script:
   - dotnet tool restore
   - dotnet cake
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a file-based script:
+</p>
+
+<pre><code class="language-yaml hljs">build_script:
+  - dotnet cake.cs
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a project:
+</p>
+
+<pre><code class="language-yaml hljs">build_script:
+  - dotnet run --project cake.csproj
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>:
+</p>
+
+<pre><code class="language-yaml hljs">build_script:
+  - dotnet run --project cake.csproj
 </code></pre>
 
 <h1 id="included-support">Available 3rd party extensions</h1>

--- a/input/docs/integrations/build-systems/azure-pipelines/index.cshtml
+++ b/input/docs/integrations/build-systems/azure-pipelines/index.cshtml
@@ -31,14 +31,44 @@ else
 <h1 id="running-cake">Running Cake</h1>
 
 <p>
-    The recommended way to run Cake on Azure Pipelines is by using a tool manifest:
+    The recommended way to run the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a> on Azure Pipelines is by using a tool manifest:
 </p>
 
 <pre><code class="language-yaml hljs">steps:
 - script: |
     dotnet tool restore
     dotnet cake
-  displayName: 'Run Cake'
+  displayName: 'Run Cake .NET Tool'
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a file-based script:
+</p>
+
+<pre><code class="language-yaml hljs">steps:
+- script: |
+    dotnet cake.cs
+  displayName: 'Run Cake.Sdk (file-based)'
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a project:
+</p>
+
+<pre><code class="language-yaml hljs">steps:
+- script: |
+    dotnet run --project cake.csproj
+  displayName: 'Run Cake.Sdk (project-based)'
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>:
+</p>
+
+<pre><code class="language-yaml hljs">steps:
+- script: |
+    dotnet run --project cake.csproj
+  displayName: 'Run Cake Frosting'
 </code></pre>
 
 <h1 id="included-support">Available 3rd party extensions</h1>

--- a/input/docs/integrations/build-systems/bamboo/index.cshtml
+++ b/input/docs/integrations/build-systems/bamboo/index.cshtml
@@ -30,12 +30,33 @@ else
 <h1 id="running-cake">Running Cake</h1>
 
 <p>
-    The recommended way to run Cake on Atlassian Bamboo is by using a tool manifest.
+    The recommended way to run the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a> on Atlassian Bamboo is by using a tool manifest.
     Add a task of type <strong>Command</strong> or <strong>Script</strong> with the following:
 </p>
 
 <pre><code class="language-bash hljs">dotnet tool restore
 dotnet cake
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a file-based script:
+</p>
+
+<pre><code class="language-bash hljs">dotnet cake.cs
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a project:
+</p>
+
+<pre><code class="language-bash hljs">dotnet run --project cake.csproj
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>:
+</p>
+
+<pre><code class="language-bash hljs">dotnet run --project cake.csproj
 </code></pre>
 
 <h1 id="included-support">Available 3rd party extensions</h1>

--- a/input/docs/integrations/build-systems/bitbucket-pipelines/index.cshtml
+++ b/input/docs/integrations/build-systems/bitbucket-pipelines/index.cshtml
@@ -30,7 +30,7 @@ else
 <h1 id="running-cake">Running Cake</h1>
 
 <p>
-    The recommended way to run Cake on Bitbucket Pipelines is by using a tool manifest:
+    The recommended way to run the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a> on Bitbucket Pipelines is by using a tool manifest:
 </p>
 
 <pre><code class="language-yaml hljs">pipelines:
@@ -39,6 +39,39 @@ else
         script:
           - dotnet tool restore
           - dotnet cake
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a file-based script:
+</p>
+
+<pre><code class="language-yaml hljs">pipelines:
+  default:
+    - step:
+        script:
+          - dotnet cake.cs
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a project:
+</p>
+
+<pre><code class="language-yaml hljs">pipelines:
+  default:
+    - step:
+        script:
+          - dotnet run --project cake.csproj
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>:
+</p>
+
+<pre><code class="language-yaml hljs">pipelines:
+  default:
+    - step:
+        script:
+          - dotnet run --project cake.csproj
 </code></pre>
 
 <h1 id="included-support">Available 3rd party extensions</h1>

--- a/input/docs/integrations/build-systems/bitrise/index.cshtml
+++ b/input/docs/integrations/build-systems/bitrise/index.cshtml
@@ -30,13 +30,37 @@ else
 <h1 id="running-cake">Running Cake</h1>
 
 <p>
-    The recommended way to run Cake on Bitrise is by using a tool manifest.
+    The recommended way to run the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a> on Bitrise is by using a tool manifest.
     Add a <strong>Script</strong> step to your workflow containing:
 </p>
 
 <pre><code class="language-bash hljs">#!/bin/bash
 dotnet tool restore
 dotnet cake
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a file-based script:
+</p>
+
+<pre><code class="language-bash hljs">#!/bin/bash
+dotnet cake.cs
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a project:
+</p>
+
+<pre><code class="language-bash hljs">#!/bin/bash
+dotnet run --project cake.csproj
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>:
+</p>
+
+<pre><code class="language-bash hljs">#!/bin/bash
+dotnet run --project cake.csproj
 </code></pre>
 
 <h1 id="included-support">Available 3rd party extensions</h1>

--- a/input/docs/integrations/build-systems/gitlab-ci/index.cshtml
+++ b/input/docs/integrations/build-systems/gitlab-ci/index.cshtml
@@ -31,12 +31,40 @@ else
 <h1 id="running-cake">Running Cake</h1>
 
 <p>
-    You can run Cake on GitLab CI/CD using the <code>dotnet cake</code> command:
+    The recommended way to run the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a> on GitLab CI/CD is by using a tool manifest:
 </p>
 
 <pre><code class="language-yaml hljs">cake_build:
   script:
+    - dotnet tool restore
     - dotnet cake
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a file-based script:
+</p>
+
+<pre><code class="language-yaml hljs">cake_build:
+  script:
+    - dotnet cake.cs
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a project:
+</p>
+
+<pre><code class="language-yaml hljs">cake_build:
+  script:
+    - dotnet run --project cake.csproj
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>:
+</p>
+
+<pre><code class="language-yaml hljs">cake_build:
+  script:
+    - dotnet run --project cake.csproj
 </code></pre>
 
 <h1 id="included-support">Available 3rd party extensions</h1>

--- a/input/docs/integrations/build-systems/jenkins/index.cshtml
+++ b/input/docs/integrations/build-systems/jenkins/index.cshtml
@@ -30,12 +30,33 @@ else
 <h1 id="running-cake">Running Cake</h1>
 
 <p>
-    The recommended way to run Cake on Jenkins is by using a tool manifest.
+    The recommended way to run the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a> on Jenkins is by using a tool manifest.
     In your Jenkinsfile or as a build step, use:
 </p>
 
 <pre><code class="language-bash hljs">dotnet tool restore
 dotnet cake
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a file-based script:
+</p>
+
+<pre><code class="language-bash hljs">dotnet cake.cs
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a project:
+</p>
+
+<pre><code class="language-bash hljs">dotnet run --project cake.csproj
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>:
+</p>
+
+<pre><code class="language-bash hljs">dotnet run --project cake.csproj
 </code></pre>
 
 <h1 id="included-support">Available 3rd party extensions</h1>

--- a/input/docs/integrations/build-systems/teamcity/index.cshtml
+++ b/input/docs/integrations/build-systems/teamcity/index.cshtml
@@ -35,12 +35,33 @@ else
 <h1 id="running-cake">Running Cake</h1>
 
 <p>
-    The recommended way to run Cake on TeamCity is by using a tool manifest.
+    The recommended way to run the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a> on TeamCity is by using a tool manifest.
     Add a <strong>command line build step</strong> with:
 </p>
 
 <pre><code class="language-bash hljs">dotnet tool restore
 dotnet cake
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a file-based script:
+</p>
+
+<pre><code class="language-bash hljs">dotnet cake.cs
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a project:
+</p>
+
+<pre><code class="language-bash hljs">dotnet run --project cake.csproj
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>:
+</p>
+
+<pre><code class="language-bash hljs">dotnet run --project cake.csproj
 </code></pre>
 
 <h1 id="included-support">Available 3rd party extensions</h1>

--- a/input/docs/integrations/build-systems/travis-ci/index.cshtml
+++ b/input/docs/integrations/build-systems/travis-ci/index.cshtml
@@ -31,12 +31,36 @@ else
 <h1 id="running-cake">Running Cake</h1>
 
 <p>
-    The recommended way to run Cake on Travis CI is by using a tool manifest:
+    The recommended way to run the <a href="/docs/running-builds/runners/dotnet-tool">Cake .NET Tool</a> on Travis CI is by using a tool manifest:
 </p>
 
 <pre><code class="language-yaml hljs">script:
   - dotnet tool restore
   - dotnet cake
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a file-based script:
+</p>
+
+<pre><code class="language-yaml hljs">script:
+  - dotnet cake.cs
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-sdk">Cake.Sdk</a> with a project:
+</p>
+
+<pre><code class="language-yaml hljs">script:
+  - dotnet run --project cake.csproj
+</code></pre>
+
+<p>
+    If you are using <a href="/docs/running-builds/runners/cake-frosting">Cake Frosting</a>:
+</p>
+
+<pre><code class="language-yaml hljs">script:
+  - dotnet run --project cake.csproj
 </code></pre>
 
 <h1 id="included-support">Available 3rd party extensions</h1>


### PR DESCRIPTION
- Add CI-native Running Cake examples for Cake.Sdk (file and project) and Cake Frosting
- Link Cake .NET Tool sections to the dotnet-tool runner docs
- Update AppVeyor, Azure Pipelines, Bamboo, Bitbucket Pipelines, Bitrise, GitLab CI/CD, Jenkins, TeamCity, and Travis CI
- Align GitLab CI/CD with tool-manifest restore and clarify Azure Pipelines step display names
- fixes #2292