### PR TITLE
Update in the news resources

### DIFF
--- a/input/community/resources/in-the-news.md
+++ b/input/community/resources/in-the-news.md
@@ -2,6 +2,25 @@ Order: 50
 Description: News pages mentioning Cake
 RedirectFrom: docs/resources/in-the-news
 ---
+# 2021
+
+## JetBrains Rider
+
+* [Cake for Rider released](/blog/2021/01/cake-for-rider)
+
+## Renovate
+
+* [Cake support in WhiteSource Renovate](/blog/2021/04/cake-support-in-renovate)
+
+# 2020
+
+## Octopus Deploy
+
+* [Thank you Octopus Deploy!](/blog/2020/10/octopus-deploy)
+
+## Dependabot
+
+* [Dependabot for Cake - Preview](/blog/2020/10/dependabot-cake-action)
 
 # 2016
 


### PR DESCRIPTION
## Summary

This pull request updates the "In the News" resource page, which currently only contains entries from 2016.

### Changes

* Added news-related entries from 2020
* Added news-related entries from 2021
* Updated the page to better reflect more recent Cake project news and resources

Fixes #1269
