### PR TITLE
fix: change Headings to H2 for TOC semantic HTML

### DIFF
--- a/config.wyam
+++ b/config.wyam
@@ -88,7 +88,7 @@ Pipelines.Add("RenderDsl",
     Documents("DslAliases"),
     Razor()
         .WithLayout("/_DslLayout.cshtml"),
-    Headings(),
+    Headings(2),
     HtmlInsert("div#infobar-headings", (doc, ctx) => ctx.GenerateInfobarHeadings(doc)),
     WriteFiles()
 );


### PR DESCRIPTION
Fixes #1080

Currently Headings() defaults to H1 for the TOC. 
Changed to Headings(2) to follow semantic HTML best practices 
— a page should only have one H1 (the title).