### PR TITLE
docs: improve script caching documentation and add invalidation option

### DIFF
--- a/input/docs/running-builds/configuration/default-configuration-values.md
+++ b/input/docs/running-builds/configuration/default-configuration-values.md
@@ -82,6 +82,9 @@ Addins=./tools/Addins</code></pre>
 </div>
 
 #  Cache compiled script on disk
+Script caching reuses previously compiled script assemblies stored on disk. This improves performance by avoiding recompilation of unchanged scripts on subsequent runs.
+
+If you need to force Cake to ignore the cached script and recompile it (for example, after changes that are not picked up automatically), you can use the `--invalidate-script-cache` option when running Cake. This will bypass the existing cache and generate a fresh compiled script.
 
 :::{.alert .alert-info}
 Available since Cake `2.2.0`.


### PR DESCRIPTION
## Summary

This PR improves the documentation for script caching in Cake by clarifying how cached script compilation improves performance and documenting how to invalidate the cache when needed.

## Changes

- Updated explanation of script caching in `default-configuration-values.md`
- Added documentation for `--invalidate-script-cache` option
- Clarified performance benefit of reused compiled script assemblies

## Notes

- Script caching is enabled via `Settings_EnableScriptCache`
- No changes were made to CLI switch definitions or global switch table
- No new features were introduced, only documentation improvements

Fixes #2431