### PR TITLE
Add Cake Frosting example to running task for collections (#2760)

### DIFF
--- a/input/docs/writing-builds/tasks/running-task-for-collections.md
+++ b/input/docs/writing-builds/tasks/running-task-for-collections.md
@@ -12,4 +12,23 @@ Task("A")
 {
     // Take action on the file.
 });
+
+```
+
+## Cake Frosting
+
+In Cake Frosting, tasks are plain C# classes, so there's no `DoesForEach` fluent method. Instead, simply iterate over the collection using a standard `foreach` loop inside the task's `Run` method.
+
+```csharp
+[TaskName("A")]
+public sealed class TaskA : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        foreach (var file in context.GetFiles("**/*.txt"))
+        {
+            // Take action on the file.
+        }
+    }
+}
 ```


### PR DESCRIPTION
Adds a Cake Frosting example to the "Running Task For Collections" page, since Frosting tasks don't have a `DoesForEach` fluent method — instead, a standard `foreach` loop is used inside the task's `Run` method.

Addresses #2760