### PR TITLE
docs(tasks): add Cake Frosting note to DoesForEach page

### DIFF
--- a/input/docs/writing-builds/tasks/running-task-for-collections.md
+++ b/input/docs/writing-builds/tasks/running-task-for-collections.md
@@ -13,3 +13,23 @@ Task("A")
     // Take action on the file.
 });
 ```
+
+:::{.alert .alert-info}
+**Cake Frosting:** Cake Frosting does not have a direct equivalent to `DoesForEach`.
+In Frosting, you can achieve similar behavior by iterating over a collection within a task's `Run` method
+and calling your logic for each item. For example:
+
+```csharp
+[TaskName("ProcessFiles")]
+public sealed class ProcessFilesTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        foreach (var file in context.GlobFiles("**/*.txt"))
+        {
+            // Take action on the file.
+        }
+    }
+}
+```
+:::


### PR DESCRIPTION
## Summary

Adds an info box to the "Running Task For Collections" page explaining that Cake Frosting does not have a direct equivalent to `DoesForEach`.

## Changes

- Added an info alert box with a code example showing how to achieve similar behavior using a loop in a Frosting task
- The example demonstrates iterating over files with `context.GlobFiles()` inside a task Run method

## Related

- Closes #2760