### PR TITLE
fix: update Cake.NScan.yml to v0.500.0 (#3445)

### DIFF
--- a/extensions/Cake.NScan.yml
+++ b/extensions/Cake.NScan.yml
@@ -17,6 +17,6 @@ Categories:
 TargetCakeVersion: 6.0.0
 TargetFrameworks:
 - net10.0
-AnalyzedPackageVersion: 0.400.0
+AnalyzedPackageVersion: 0.500.0
 AnalyzedPackageIsPrerelease: false
-AnalyzedPackagePublishDate: 2026-01-02T20:26:31.2600000Z
+AnalyzedPackagePublishDate: 2026-07-08T00:00:00.0000000Z


### PR DESCRIPTION
Fixes #3445

## Problem
The Cake.AddinDiscoverer tool detected that Cake.NScan.yml was out of sync
with the package metadata published on NuGet.org — the site still listed
v0.400.0 while v0.500.0 had since been published.

## Solution
Updated the analyzed package fields to reflect the currently published
version of Cake.NScan on NuGet.org.

## Changes
- `extensions/Cake.NScan.yml`: bumped `AnalyzedPackageVersion` from 0.400.0
  to 0.500.0 and updated `AnalyzedPackagePublishDate` accordingly.
  All other metadata (description, categories, target framework, target
  Cake version) is unchanged between the two versions.

## Notes / Tradeoffs
`AnalyzedPackagePublishDate` reflects the publish date shown on NuGet.org;
the exact time-of-day component wasn't independently verifiable and is
set to 00:00:00 UTC.